### PR TITLE
NSL-3658 - Add a parent and second parent dropdowns when copying a hybrid name

### DIFF
--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -124,7 +124,9 @@ class NamesController < ApplicationController
     logger.debug("copy")
     current_name = Name::AsCopier.find(params[:id])
     @name = current_name.copy_with_username(name_params[:name_element],
-                                            current_user.username)
+                                            current_user.username,
+                                            parent_id: name_params[:parent_id],
+                                            second_parent_id: name_params[:second_parent_id])
     render "names/copy/success"
   rescue StandardError => e
     @message = e.to_s
@@ -268,6 +270,8 @@ class NamesController < ApplicationController
                                  :published_year,
                                  :changed_combination,
                                  :target_name_id,
+                                 :parent_id,
+                                 :second_parent_id,
                                  instance_ids_to_copy: [])
   end
 

--- a/app/javascript/controllers/copy_name_form_controller.js
+++ b/app/javascript/controllers/copy_name_form_controller.js
@@ -1,0 +1,55 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="copy-name-form"
+//
+// Guards the "copy a hybrid name" form: clears the parent typeaheads on load so
+// the copy cannot silently inherit the original's parents, and validates the
+// chosen parents on submit.
+export default class extends Controller {
+  static values = {
+    originalParentId: String,
+    originalSecondParentId: String,
+    cultivarHybrid: Boolean
+  }
+
+  connect() {
+    this.clearParent("name-parent-typeahead", "name_parent_id")
+    this.clearParent("name-second-parent-typeahead", "name_second_parent_id")
+  }
+
+  // Start empty so the copy cannot silently inherit the original's parents.
+  clearParent(typeaheadId, hiddenId) {
+    const $typeahead = window.$("#" + typeaheadId)
+    if ($typeahead.hasClass("tt-input")) {
+      $typeahead.typeahead("val", "")
+    }
+    $typeahead.val("")
+    window.$("#" + hiddenId).val("")
+  }
+
+  // Wired via data-action="submit->copy-name-form#validate"
+  validate(event) {
+    const firstParent = document.getElementById("name_parent_id").value
+    const secondParent = document.getElementById("name_second_parent_id").value
+    let message = null
+
+    if (!firstParent) {
+      message = "Please choose a first parent for the copy."
+    } else if (firstParent === this.originalParentIdValue) {
+      message = "The first parent must differ from the original name's first parent."
+    } else if (!secondParent) {
+      message = "Please choose a second parent for the copy."
+    } else if (secondParent === this.originalSecondParentIdValue) {
+      message = "The second parent must differ from the original name's second parent."
+    } else if (!this.cultivarHybridValue && firstParent === secondParent) {
+      message = "The second parent cannot be the same as the first parent."
+    }
+
+    if (message) {
+      event.preventDefault()
+      event.stopImmediatePropagation()
+      window.$("#copy-name-info-message-container").html("").addClass("hidden")
+      window.$("#copy-name-error-message-container").html(message).removeClass("hidden")
+    }
+  }
+}

--- a/app/models/concerns/name/instances_copyable.rb
+++ b/app/models/concerns/name/instances_copyable.rb
@@ -9,7 +9,7 @@ module Name::InstancesCopyable
   end
 
   def standalone_instances_sorted
-    standalone_instances.sort {|x,y| x.reference.iso_publication_date <=> y.reference.iso_publication_date}
+    standalone_instances.sort_by {|si| si.reference&.iso_publication_date.to_s}
   end
 
   def standalone_instance_ids

--- a/app/models/name/as_copier.rb
+++ b/app/models/name/as_copier.rb
@@ -129,6 +129,7 @@ class Name::AsCopier < Name
     new.uri = new.source_system = new.source_id_string = nil
     new.source_id = nil
     new.lock_version = 0
+    new.name_status = NameStatus.not_applicable if hybrid?
     new.save!
     new.set_names!
     new.refresh_name_paths

--- a/app/models/name/as_copier.rb
+++ b/app/models/name/as_copier.rb
@@ -112,13 +112,19 @@
 #
 class Name::AsCopier < Name
   NAC = "Name::AsCopier"
-  def copy_with_username(new_name_element, as_username)
+  def copy_with_username(new_name_element, as_username, parent_id: nil, second_parent_id: nil)
     Rails.logger.debug("#{NAC}#copy with username
                        new_name_element: #{new_name_element}")
     raise "Copied record would have the same name." if new_name_element.eql?(name_element)
 
+    validate_new_hybrid_parents!(parent_id, second_parent_id) if hybrid?
+
     new = dup
     new.name_element = new_name_element
+
+    new.parent_id = parent_id if parent_id.present?
+    new.second_parent_id = second_parent_id if second_parent_id.present?
+
     new.created_by = new.updated_by = as_username
     new.uri = new.source_system = new.source_id_string = nil
     new.source_id = nil
@@ -171,5 +177,23 @@ class Name::AsCopier < Name
       raise("Name not copied")
     end
     copied_name
+  end
+
+  private
+
+  def validate_new_hybrid_parents!(parent_id, second_parent_id)
+    if parent_id.blank? || parent_id.to_i == self.parent_id
+      raise "Please choose a first parent that is different from " \
+            "the original name's first parent."
+    end
+
+    if second_parent_id.blank? || second_parent_id.to_i == self.second_parent_id
+      raise "Please choose a second parent that is different from " \
+            "the original name's second parent."
+    end
+
+    if !cultivar_hybrid? && parent_id.to_i == second_parent_id.to_i
+      raise "The second parent cannot be the same as the first parent."
+    end
   end
 end

--- a/app/views/names/form/_copy.html.erb
+++ b/app/views/names/form/_copy.html.erb
@@ -1,9 +1,20 @@
+<% copy_form_data = {} %>
+<% if @name.hybrid? %>
+  <% copy_form_data = {
+       controller: "copy-name-form",
+       copy_name_form_original_parent_id_value: @name.parent_id,
+       copy_name_form_original_second_parent_id_value: @name.second_parent_id,
+       copy_name_form_cultivar_hybrid_value: @name.cultivar_hybrid?,
+       action: "submit->copy-name-form#validate"
+     } %>
+<% end %>
 <%= form_for(@name,
              url: name_copy_path(id: @name.id),
              html: {id: "copy-name-form",
                     role: 'form',
                     remote: true,
-                    method: :post}) do |f| %>
+                    method: :post,
+                    data: copy_form_data}) do |f| %>
  <% if @name.errors.any? %>
     <div id="error_explanation">
       <h6><%= pluralize(@name.errors.count, "error") %> prohibited this name from being saved:</h6>
@@ -23,59 +34,10 @@
   </div>
 
 <div class="width-100-percent">
-  hybrid: <%= @name.hybrid? %><br/>
-  parent_id: <%= @name.parent_id %><br/>
-  name_second_parent_id: <%= @name.second_parent_id %><br/><br/>
-
   <% if @name.hybrid? %>
     <%= hidden_field(:name, :name_rank_id, value: @name.name_rank_id) %>
     <%= render partial: 'names/form/parent_1' %>
     <%= render partial: 'names/form/parent_2' %>
-
-    <script>
-      $(function () {
-        var originalParentId = '<%= @name.parent_id %>';
-        var originalSecondParentId = '<%= @name.second_parent_id %>';
-        var cultivarHybrid = <%= @name.cultivar_hybrid? %>;
-
-        // Start empty so the copy cannot silently inherit the original's parents.
-        function clearParent(typeaheadId, hiddenId) {
-          var $typeahead = $('#' + typeaheadId);
-          if ($typeahead.hasClass('tt-input')) {
-            $typeahead.typeahead('val', '');
-          }
-          $typeahead.val('');
-          $('#' + hiddenId).val('');
-        }
-        clearParent('name-parent-typeahead', 'name_parent_id');
-        clearParent('name-second-parent-typeahead', 'name_second_parent_id');
-
-        $('#copy-name-form').on('submit', function (e) {
-          var firstParent = $('#name_parent_id').val();
-          var secondParent = $('#name_second_parent_id').val();
-          var message = null;
-
-          if (!firstParent) {
-            message = 'Please choose a first parent for the copy.';
-          } else if (firstParent === originalParentId) {
-            message = "The first parent must differ from the original name's first parent.";
-          } else if (!secondParent) {
-            message = 'Please choose a second parent for the copy.';
-          } else if (secondParent === originalSecondParentId) {
-            message = "The second parent must differ from the original name's second parent.";
-          } else if (!cultivarHybrid && firstParent === secondParent) {
-            message = 'The second parent cannot be the same as the first parent.';
-          }
-
-          if (message) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-            $('#copy-name-info-message-container').html('').addClass('hidden');
-            $('#copy-name-error-message-container').html(message).removeClass('hidden');
-          }
-        });
-      });
-    </script>
   <% end %>
 
   <%= link_to("Copy...",

--- a/app/views/names/form/_copy.html.erb
+++ b/app/views/names/form/_copy.html.erb
@@ -22,18 +22,72 @@
    <%= f.text_field :name_element, class: 'form-control give-me-focus', required: @name.requires_name_element?, tabindex: increment_tab_index, title: "Change this value to the new name for the copy.", autofocus: true %>
   </div>
 
-<div class="width-100-percent"> 
+<div class="width-100-percent">
+  hybrid: <%= @name.hybrid? %><br/>
+  parent_id: <%= @name.parent_id %><br/>
+  name_second_parent_id: <%= @name.second_parent_id %><br/><br/>
+
+  <% if @name.hybrid? %>
+    <%= hidden_field(:name, :name_rank_id, value: @name.name_rank_id) %>
+    <%= render partial: 'names/form/parent_1' %>
+    <%= render partial: 'names/form/parent_2' %>
+
+    <script>
+      $(function () {
+        var originalParentId = '<%= @name.parent_id %>';
+        var originalSecondParentId = '<%= @name.second_parent_id %>';
+        var cultivarHybrid = <%= @name.cultivar_hybrid? %>;
+
+        // Start empty so the copy cannot silently inherit the original's parents.
+        function clearParent(typeaheadId, hiddenId) {
+          var $typeahead = $('#' + typeaheadId);
+          if ($typeahead.hasClass('tt-input')) {
+            $typeahead.typeahead('val', '');
+          }
+          $typeahead.val('');
+          $('#' + hiddenId).val('');
+        }
+        clearParent('name-parent-typeahead', 'name_parent_id');
+        clearParent('name-second-parent-typeahead', 'name_second_parent_id');
+
+        $('#copy-name-form').on('submit', function (e) {
+          var firstParent = $('#name_parent_id').val();
+          var secondParent = $('#name_second_parent_id').val();
+          var message = null;
+
+          if (!firstParent) {
+            message = 'Please choose a first parent for the copy.';
+          } else if (firstParent === originalParentId) {
+            message = "The first parent must differ from the original name's first parent.";
+          } else if (!secondParent) {
+            message = 'Please choose a second parent for the copy.';
+          } else if (secondParent === originalSecondParentId) {
+            message = "The second parent must differ from the original name's second parent.";
+          } else if (!cultivarHybrid && firstParent === secondParent) {
+            message = 'The second parent cannot be the same as the first parent.';
+          }
+
+          if (message) {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            $('#copy-name-info-message-container').html('').addClass('hidden');
+            $('#copy-name-error-message-container').html(message).removeClass('hidden');
+          }
+        });
+      });
+    </script>
+  <% end %>
 
   <%= link_to("Copy...",
-             '#',
-             id: "copy-name-link",
-             class: "btn btn-warning unconfirmed-action-link pull-right",
-             title: "Copy the name - you will be asked to confirm.",
-             tabindex: increment_tab_index,
-             data: {show_this_id: "confirm-or-cancel-copy-name-link-container"})
+            '#',
+            id: "copy-name-link",
+            class: "btn btn-warning unconfirmed-action-link pull-right",
+            title: "Copy the name - you will be asked to confirm.",
+            tabindex: increment_tab_index,
+            data: {show_this_id: "confirm-or-cancel-copy-name-link-container"})
   %>
   <div id="confirm-or-cancel-copy-name-link-container"
-       class="confirm-or-cancel-container pull-right hidden">
+      class="confirm-or-cancel-container pull-right hidden">
 
     <%= f.submit "Confirm", id: 'create-copy-of-name', class: 'btn btn-primary width-7em', title: 'Really copy the name', disabled: false, tabindex: increment_tab_index %>
     <%= link_to("Cancel",
@@ -45,6 +99,7 @@
                 data: {enable_this_id: 'copy-name-link',
                 hide_this_id: "confirm-or-cancel-copy-name-link-container"})
     %>
+
   </div>
   <div id="copy-name-info-message-container" class="message-container hidden"></div>
   <div id="copy-name-error-message-container" class="error-container hidden"></div>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 07-July-2026
+  :jira_id: '3658'
+  :description: |-
+    Show a parent and second parent dropdowns when copying a hybrid name and set the name status to n/a in the copier
+- :date: 07-July-2026
   :jira_id: '5603'
   :description: |-
     Loader: List misapplications in chronological order
@@ -29,7 +33,7 @@
 - :date: 30-June-2026
   :jira_id: '5818'
   :description: |-
-    Name Editing: improve notification when a name author has no abbreviation 
+    Name Editing: improve notification when a name author has no abbreviation
 - :date: 30-June-2026
   :jira_id: '4573'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.26
+appversion=5.1.4.27

--- a/spec/models/concerns/name/instances_copyable_spec.rb
+++ b/spec/models/concerns/name/instances_copyable_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Name::InstancesCopyable, type: :model do
+  let(:name) { FactoryBot.create(:name) }
+
+  def standalone_instance_for(target_name, iso:)
+    reference = FactoryBot.create(:reference, iso_publication_date: iso)
+    instance_type = FactoryBot.create(:instance_type, standalone: true,
+                                                      primary_instance: false)
+    FactoryBot.create(:instance, name: target_name, reference: reference,
+                                 instance_type: instance_type)
+  end
+
+  describe "#standalone_instances_sorted" do
+    it "does not raise when a reference has a nil iso_publication_date" do
+      standalone_instance_for(name, iso: "2001-01-01")
+      standalone_instance_for(name, iso: nil)
+
+      expect { name.standalone_instances_sorted }.not_to raise_error
+    end
+
+    it "orders by iso_publication_date with nil sorting first" do
+      later   = standalone_instance_for(name, iso: "2010")
+      undated = standalone_instance_for(name, iso: nil)
+      earlier = standalone_instance_for(name, iso: "2000")
+
+      expect(name.standalone_instances_sorted).to eq([undated, earlier, later])
+    end
+
+    it "returns an empty array when there are no standalone instances" do
+      expect(name.standalone_instances_sorted).to eq([])
+    end
+  end
+end

--- a/spec/models/name/as_copier_spec.rb
+++ b/spec/models/name/as_copier_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.describe Name::AsCopier, type: :model do
+  let!(:na_status) { FactoryBot.create(:name_status, name: "[n/a]") }
+
+  let(:hybrid_type)     { FactoryBot.create(:name_type, hybrid: true) }
+  let(:non_hybrid_type) { FactoryBot.create(:name_type, hybrid: false) }
+
+  before do
+    allow_any_instance_of(Name).to receive(:set_names!)
+    allow_any_instance_of(Name).to receive(:refresh_name_paths)
+  end
+
+  describe "#copy_with_username" do
+    it "raises when the new name element equals the original" do
+      source = described_class.find(
+        FactoryBot.create(:name, name_type: non_hybrid_type, name_element: "same").id
+      )
+
+      expect { source.copy_with_username("same", "tester") }
+        .to raise_error("Copied record would have the same name.")
+    end
+
+    context "when the source name is not a hybrid" do
+      let(:legit)  { FactoryBot.create(:name_status, name: "legitimate") }
+      let(:source) do
+        described_class.find(
+          FactoryBot.create(:name, name_type: non_hybrid_type,
+                                   name_status: legit, name_element: "orig").id
+        )
+      end
+
+      it "keeps the duplicated status (does NOT force [n/a])" do
+        copy = source.copy_with_username("newelement", "tester")
+        expect(copy.name_status).to eq(legit)
+      end
+
+      it "resets uri, source fields and lock_version on the copy" do
+        copy = source.copy_with_username("newelement", "tester")
+
+        aggregate_failures do
+          expect(copy.uri).to be_nil
+          expect(copy.source_system).to be_nil
+          expect(copy.source_id_string).to be_nil
+          expect(copy.source_id).to be_nil
+          expect(copy.lock_version).to eq(0)
+          expect(copy.created_by).to eq("tester")
+          expect(copy.updated_by).to eq("tester")
+        end
+      end
+    end
+
+    context "when the source name is a hybrid" do
+      let(:first_parent)  { FactoryBot.create(:name) }
+      let(:second_parent) { FactoryBot.create(:name) }
+      let(:source) do
+        described_class.find(
+          FactoryBot.create(:name, name_type: non_hybrid_type, name_element: "orig").id
+        )
+      end
+
+      before do
+        allow(source).to receive(:hybrid?).and_return(true)
+        allow(source).to receive(:cultivar_hybrid?).and_return(false)
+      end
+
+      def copy_with(parent_id:, second_parent_id:)
+        source.copy_with_username("newelement", "tester",
+                                  parent_id: parent_id,
+                                  second_parent_id: second_parent_id)
+      end
+
+      context "with two valid, distinct parents" do
+        before do
+          allow_any_instance_of(Name).to receive(:takes_parent_2?).and_return(true)
+        end
+
+        it "forces the copy's status to [n/a]" do
+          copy = copy_with(parent_id: first_parent.id,
+                           second_parent_id: second_parent.id)
+          expect(copy.name_status).to eq(na_status)
+        end
+
+        it "assigns the chosen parents to the copy" do
+          copy = copy_with(parent_id: first_parent.id,
+                           second_parent_id: second_parent.id)
+
+          aggregate_failures do
+            expect(copy.parent_id).to eq(first_parent.id)
+            expect(copy.second_parent_id).to eq(second_parent.id)
+          end
+        end
+      end
+
+      it "raises when the first parent is blank" do
+        expect { copy_with(parent_id: nil, second_parent_id: second_parent.id) }
+          .to raise_error(/first parent that is different/)
+      end
+
+      it "raises when the second parent is blank" do
+        expect { copy_with(parent_id: first_parent.id, second_parent_id: nil) }
+          .to raise_error(/second parent that is different/)
+      end
+
+      it "raises when both parents are the same (non cultivar-hybrid)" do
+        expect { copy_with(parent_id: first_parent.id, second_parent_id: first_parent.id) }
+          .to raise_error("The second parent cannot be the same as the first parent.")
+      end
+    end
+  end
+end

--- a/test/integration/name/copy/hybrid_test.rb
+++ b/test/integration/name/copy/hybrid_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Exercises the "copy a hybrid name" workflow that the copy form drives:
+# POST names/:id/copy with a new element and two chosen parents.
+class NamesCopyHybridTest < ActionController::TestCase
+  tests NamesController
+
+  def setup
+    @source = names(:hybrid_formula) # parent: a_species, second_parent: another_species
+    # New parents, distinct from the source's own parents (the form requires this).
+    @new_first_parent = names(:triodia_basedowii)
+    @new_second_parent = names(:crotalaria_distans)
+    @edit_session = { username: "fred",
+                      user_full_name: "Fred Jones",
+                      groups: ["edit"] }
+  end
+
+  def post_copy(name_element:, parent_id:, second_parent_id:)
+    post(:copy,
+         params: { name: { "name_element" => name_element,
+                           "name_rank_id" => @source.name_rank_id.to_s,
+                           "parent_id" => parent_id.to_s,
+                           "second_parent_id" => second_parent_id.to_s },
+                   format: :js,
+                   "id" => @source.id.to_s },
+         session: @edit_session)
+  end
+
+  test "copying a hybrid name creates a new name with [n/a] status and the chosen parents" do
+    new_name = nil
+
+    Name.stub_any_instance(:set_names!, nil) do
+      Name.stub_any_instance(:refresh_name_paths, 0) do
+        assert_difference("Name.count", 1) do
+          post_copy(name_element: "hybrid copy",
+                    parent_id: @new_first_parent.id,
+                    second_parent_id: @new_second_parent.id)
+        end
+        new_name = Name.find_by(name_element: "hybrid copy")
+      end
+    end
+
+    assert_not_nil new_name, "the copied name should have been created"
+    assert_equal "[n/a]", new_name.name_status.name
+    assert_equal @new_first_parent.id, new_name.parent_id
+    assert_equal @new_second_parent.id, new_name.second_parent_id
+  end
+
+  test "copying a hybrid name reusing the original's first parent does not create a new name" do
+    assert_difference("Name.count", 0) do
+      post_copy(name_element: "hybrid copy",
+                parent_id: @source.parent_id,
+                second_parent_id: @new_second_parent.id)
+    end
+  end
+
+  test "copying a hybrid name reusing the original's second parent does not create a new name" do
+    assert_difference("Name.count", 0) do
+      post_copy(name_element: "hybrid copy",
+                parent_id: @new_first_parent.id,
+                second_parent_id: @source.second_parent_id)
+    end
+  end
+end


### PR DESCRIPTION
## Description
Add dropdowns for the first and second parent selection when copying a hybrid name. 

This change also includes updating the name copier to set the new parent and second parent as well as setting the name status to n/a for hybrid name copy. Validations were also added so that user cannot add the same parents for new the copy.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
