### PR TITLE
NSL-2423: Synonym display: adjust logic for cases where name status exists but is not displayed

### DIFF
--- a/app/models/concerns/instance/displayable.rb
+++ b/app/models/concerns/instance/displayable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Instance::Displayable
+  extend ActiveSupport::Concern
+
+  def needs_a_comma?
+    page.present? ||
+      (name.name_status.present? &&
+       name.name_status.name_for_instance_display.present?)
+  end
+end

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -79,6 +79,7 @@ class Instance < ApplicationRecord
   include InstanceInTaxonomy
   include Instance::ForCopyToLoaderName
   include Instance::CopyableToNewName
+  include Instance::Displayable
 
   self.table_name = "instance"
   self.primary_key = "id"

--- a/app/views/application/search_results/instance/_instance_is_cited_by.html.erb
+++ b/app/views/application/search_results/instance/_instance_is_cited_by.html.erb
@@ -18,7 +18,7 @@
     title="Instance is cited by record.  Select to show details."
     tabindex="<%= increment_tab_index %>">
       <%= "#{search_result.expanded_instance_type || search_result.instance_type.name}:" %>
-      <%= "<b>#{search_result.name.full_name_html}</b>".html_safe %><%= "," unless search_result.name.name_status.blank? && search_result.page.blank? %>
+      <%= "<b>#{search_result.name.full_name_html}</b>".html_safe %><%= "," if search_result.needs_a_comma? %>
       <%= " #{search_result.name.name_status.name_for_instance_display}" %>
       <%= "#{search_result.page}" %>
       <%= render(partial: 'draft', locals: { search_result: search_result }) %>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 08-July-2026
+  :jira_id: '2423'
+  :description: |-
+    Synonym display: adjust logic for cases where name status exists but is not displayed
 - :date: 07-July-2026
   :jira_id: '5829'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.28
+appversion=5.1.4.29

--- a/test/models/concerns/instance/displayable_test.rb
+++ b/test/models/concerns/instance/displayable_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Instance::Displayable#needs_a_comma? decides whether the "cited by" search
+# result line needs a comma between the name and whatever follows it (a name
+# status tag and/or a page number).
+class Instance::DisplayableTest < ActiveSupport::TestCase
+  test "needs a comma when the instance has a page, regardless of status" do
+    instance = instances(:britten_created_angophora_costata)
+    assert instance.page.present?, "fixture should have a page"
+    assert instance.needs_a_comma?
+  end
+
+  test "needs a comma when there is no page but the status has display text" do
+    instance = instances(:has_no_page_bhl_url_verbatim_name_string)
+    assert instance.page.blank?, "fixture should have no page"
+    assert instance.name.name_status.name_for_instance_display.present?,
+           "fixture status should render display text"
+    assert instance.needs_a_comma?
+  end
+
+  test "does not need a comma when there is no page and status is legitimate" do
+    instance = Instance.new(
+      name: names(:a_species),
+      reference: references(:dummy_reference_1),
+      instance_type: instance_types(:comb_nov),
+    )
+    assert instance.name.name_status.legitimate?, "fixture status should be legitimate"
+    assert instance.page.blank?
+    assert_not instance.needs_a_comma?
+  end
+
+  test "does not need a comma when there is no page and status is n/a" do
+    instance = Instance.new(
+      name: names(:argyle_apple),
+      reference: references(:dummy_reference_1),
+      instance_type: instance_types(:comb_nov),
+    )
+    assert instance.name.name_status.na?, "fixture status should be n/a"
+    assert instance.page.blank?
+    assert_not instance.needs_a_comma?
+  end
+
+  test "needs a comma when there is a page even if status has no display text" do
+    instance = instances(:default_instance_for_a_genus)
+    assert instance.page.present?, "fixture should have a page"
+    assert instance.name.name_status.legitimate?, "fixture status should be legitimate"
+    assert instance.needs_a_comma?
+  end
+end


### PR DESCRIPTION
## Description

Claude's summary:

Extracts the "does this cited-by row need a trailing comma" logic out of the view into a new `Instance::Displayable` concern, included in Instance, and swaps the inline erb condition for `search_result.needs_a_comma?`.

The logic is actually improved, not just moved. The old condition was:

`unless search_result.name.name_status.blank? && search_result.page.blank?`

i.e. comma shown whenever `name_status.present? || page.present?`. 

But `name_status.name_for_instance_display` returns "" for legitimate/N/A statuses (see name_status.rb:86-88). So a legitimate name with no page got a comma printed followed by nothing — a dangling "Full Name, " in the UI. 

The new version:

`page.present? || (name.name_status.present? && name.name_status.name_for_instance_display.present?)`

only adds the comma when there's actually a page or actually a non-empty status string to follow it. 

That's a genuine bug fix (this whole feature was NSL-2423, commit 811cd9938), not a pure refactor.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
See Jira


## Tests
- [x] Unit tests - from Claude
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
