### PR TITLE
NSL-5708 - Fix typos in search results display logic and standardize …

### DIFF
--- a/app/views/search/review/_results.html.erb
+++ b/app/views/search/review/_results.html.erb
@@ -1,47 +1,41 @@
-      <caption class="hidden">Results of the latest search</caption>
-      <% @focus_anchor_id = params[:focus] unless params[:focus].blank? %>            
-    <% for record in @search.executed_query.results %><%# Allow for hashes or ActiveRecords, so use hash key syntax. %>
-      <% if record[:anchor_id] == @focus_anchor_id %>
-        <% give_me_focus = true  %>
-        <%  @focus_anchor_id = 'do not use again'  %>
-      <% else %>
-       <% give_me_focus = false %>
-      <% end %>
+<caption class="hidden">Results of the latest search</caption>
+<% focus_anchor_id = params[:focus].presence %>
+<% focus_claimed = false %>
+<% for record in @search.executed_query&.results || [] %><%# Allow for hashes or ActiveRecords, so use hash key syntax. %>
+  <% give_me_focus = !focus_claimed && record[:anchor_id] == focus_anchor_id %>
+  <% focus_claimed = true if give_me_focus %>
 
-      <% display_as = record.class.name == 'Hash' ? record[:display_as] || record.class.to_s  : record.try('display_as') || record.class.to_s %>
-      <%# TODO: standardize on strings or symbols, at least for the instance record variants. %>
-      <% case display_as %>
-      <% when 'Loader Batch' %>  
-        <%= render partial: 'application/search_results/review/loader_batch_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Loader Name' %>  
-        <%= render partial: 'application/search_results/review/loader_name_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-        <% @flush_loader_name = true %>
-      <% when 'Name Review Comment' %>  
-        <%# Do nothing for now %>
-      <% else %>
-        <tr>
-          <td class="width-1-percent"></td>
-          <td class="min-with-40-percent width-50-percent max-width-60-percent">
-            <%= display_as %> is an unknown type of search result in review mode
-          </td>
-          <td class="width-5-perent filler"></td>
-        </tr>
-      <% end %>
-    <% end %>
-
-    <% if @flush_loader_name %>
-    <%= render partial: 'application/search_results/review/loader_name_record', 
-        locals: {search_result: Loader::Name.record_to_flush_results, give_me_focus: false} %>
-    <% end %>
-
+  <% display_as = record.class.name == 'Hash' ? record[:display_as] || record.class.to_s  : record.try('display_as') || record.class.to_s %>
+  <%# TODO: standardize on strings or symbols, at least for the instance record variants. %>
+  <% case display_as&.to_s %>
+  <% when 'Loader Batch' %>
+    <%= render partial: 'application/search_results/review/loader_batch_record',
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'Loader Name' %>
+    <%= render partial: 'application/search_results/review/loader_name_record',
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% @flush_loader_name = true %>
+  <% when 'Name Review Comment' %>
+    <%# Do nothing for now %>
+  <% else %>
     <tr>
       <td class="width-1-percent"></td>
       <td class="min-with-40-percent width-50-percent max-width-60-percent">
-        <br> <br> <br> <br> <br>
+        <%= display_as %> is an unknown type of search result in review mode
       </td>
-      <td class="width-5-percent filler"></td>
+      <td class="width-5-perent filler"></td>
     </tr>
+  <% end %>
+<% end %>
 
+<% if @flush_loader_name %>
+  <%= render partial: 'application/search_results/review/loader_name_record', locals: {search_result: Loader::Name.record_to_flush_results, give_me_focus: false} %>
+<% end %>
 
+<tr>
+  <td class="width-1-percent"></td>
+  <td class="min-with-40-percent width-50-percent max-width-60-percent">
+    <br> <br> <br> <br> <br>
+  </td>
+  <td class="width-5-percent filler"></td>
+</tr>

--- a/app/views/search/standard/_results.html.erb
+++ b/app/views/search/standard/_results.html.erb
@@ -1,126 +1,125 @@
 <% partials = 'application/search_results' %>
-      <caption class="hidden">Results of the latest search</caption>
-      <% @focus_anchor_id = params[:focus] unless params[:focus].blank? %>
-    <% for record in @search.executed_query.results %><%# Allow for hashes or ActiveRecords, so use hash key syntax. %>
-      <% if record[:anchor_id] == @focus_anchor_id %>
-        <% give_me_focus = true  %>
-        <%  @focus_anchor_id = 'do not use again'  %>
-      <% else %>
-       <% give_me_focus = false %>
-      <% end %>
+<caption class="hidden">Results of the latest search</caption>
 
-      <% display_as = record.class.name == 'Hash' ? record[:display_as] || record.class.to_s  : record.try('display_as') || record.class.to_s %>
-      <%# TODO: standardize on strings or symbols, at least for the instance record variants. %>
-      <% case display_as&.to_s %>
-      <% when 'Reference' %>
-        <%= render partial: "#{partials}/reference_record",
-          locals: {reference: record, give_me_focus: give_me_focus} %>
-      <% when 'reference_as_part_of_concept' %>
-        <%= render partial: "#{partials}/reference_as_part_of_concept_record",
-          locals: {reference: record, give_me_focus: give_me_focus} %>
-      <% when 'Author' %>
-        <%= render partial: "#{partials}/author_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Name' %>
-        <%= render partial: "#{partials}/name_record", locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'name_as_part_of_concept' %>
-        <%= render partial: "#{partials}/name_as_part_of_instance_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'instance_as_part_of_concept' %>
-        <%= render partial: "#{partials}/instance/instance_as_part_of_concept_record",
-          locals: {search_result: record, give_me_focus: give_me_focus}%>
-      <% when 'citing_instance_within_name_search' %>
-        <%= render partial: "#{partials}/instance/citing_instance_within_name_search_record",
-          locals: {search_result: record, give_me_focus: give_me_focus}%>
-      <% when 'instance_within_reference' %>
-        <%= render partial: "#{partials}/instance/instance_within_reference_record",
-          locals: {search_result: record, give_me_focus: give_me_focus}%>
-      <% when 'Instance' %>
-        <%= render partial: "#{partials}/instance/instance_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'cites-this-instance' %>
-        <%= render partial: "#{partials}/instance/instance_cites_this_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'name-cited-by-instance' %>
-        <%= render partial: "#{partials}/instance/instance_cited_by_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'instance-is-cited-by' %>
-        <%= render partial: "#{partials}/instance/instance_is_cited_by",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'cited-by-instance' %>
-        <%= render partial: "#{partials}/instance/cited_by_instance",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'cited-by-instance-within-full-synonymy' %>
-        <%= render partial: "#{partials}/instance/instance_cited_by_record_within_full_synonymy",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-     <% when 'cited-by-relationship-instance' %>
-       <%= render partial: "#{partials}/instance/instance_cited_by_relationship_instance_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'cited-by-relationship-instance-name-only' %>
-        <%= render partial: "#{partials}/instance/instance_cited_by_relationship_instance_name_only",
-           locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'instance-for-expansion' %>
-        <%= render partial: "#{partials}/instance/instance_for_expansion_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Loader Batch' %>
-        <%= render partial: "#{partials}/loader_batch_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Loader Batch in stack' %>
-        <%= render partial: "#{partials}/stack/loader_batch_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Loader Name' %>
-        <%= render partial: "#{partials}/loader_name_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Batch Review' %>
-        <%= render partial: "#{partials}/batch_review_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Batch Review in stack' %>
-        <%= render partial: "#{partials}/stack/batch_review_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Batch Reviewer' %>
-        <%= render partial: "#{partials}/batch_reviewer_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Batch Reviewer in stack' %>
-        <%= render partial: "#{partials}/stack/batch_reviewer_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Review Period' %>
-        <%= render partial: "#{partials}/review_period_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Review Period in stack' %>
-        <%= render partial: "#{partials}/stack/review_period_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'BulkProcessingLog' %>
-        <%= render partial: "#{partials}/bulk_processing_log_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'User' %>
-        <%= render partial: "#{partials}/user_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Organisation' %>
-        <%= render partial: "#{partials}/org_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Name Review Comment' %>
-        <%= render partial: "#{partials}/main/loader/name/review/comment_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Profile::ProfileItem' %>
-        <%= render partial: "#{partials}/profile_item_record",
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% else %>
-        <tr>
-          <td class="width-1-percent"></td>
-          <td class="min-width-40-percent width-50-percent max-width-60-percent">
-            <%= display_as&.to_s %> is an unknown type of standard search result
-          </td>
-          <td class="width-5-percent filler"></td>
-        </tr>
-      <% end %>
-    <% end %>
+<% focus_anchor_id = params[:focus].presence %>
+<% focus_claimed = false %>
 
-    <tr class="results-row-filler">
+<% for record in @search.executed_query&.results || [] %><%# Allow for hashes or ActiveRecords, so use hash key syntax. %>
+  <% give_me_focus = !focus_claimed && record[:anchor_id] == focus_anchor_id %>
+  <% focus_claimed = true if give_me_focus %>
+
+  <% display_as = record.class.name == 'Hash' ? record[:display_as] || record.class.to_s  : record.try('display_as') || record.class.to_s %>
+  <%# TODO: standardize on strings or symbols, at least for the instance record variants. %>
+  <% case display_as&.to_s %>
+  <% when 'Reference' %>
+    <%= render partial: "#{partials}/reference_record",
+      locals: {reference: record, give_me_focus: give_me_focus} %>
+  <% when 'reference_as_part_of_concept' %>
+    <%= render partial: "#{partials}/reference_as_part_of_concept_record",
+      locals: {reference: record, give_me_focus: give_me_focus} %>
+  <% when 'Author' %>
+    <%= render partial: "#{partials}/author_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'Name' %>
+    <%= render partial: "#{partials}/name_record", locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'name_as_part_of_concept' %>
+    <%= render partial: "#{partials}/name_as_part_of_instance_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'instance_as_part_of_concept' %>
+    <%= render partial: "#{partials}/instance/instance_as_part_of_concept_record",
+      locals: {search_result: record, give_me_focus: give_me_focus}%>
+  <% when 'citing_instance_within_name_search' %>
+    <%= render partial: "#{partials}/instance/citing_instance_within_name_search_record",
+      locals: {search_result: record, give_me_focus: give_me_focus}%>
+  <% when 'instance_within_reference' %>
+    <%= render partial: "#{partials}/instance/instance_within_reference_record",
+      locals: {search_result: record, give_me_focus: give_me_focus}%>
+  <% when 'Instance' %>
+    <%= render partial: "#{partials}/instance/instance_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'cites-this-instance' %>
+    <%= render partial: "#{partials}/instance/instance_cites_this_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'name-cited-by-instance' %>
+    <%= render partial: "#{partials}/instance/instance_cited_by_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'instance-is-cited-by' %>
+    <%= render partial: "#{partials}/instance/instance_is_cited_by",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'cited-by-instance' %>
+    <%= render partial: "#{partials}/instance/cited_by_instance",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'cited-by-instance-within-full-synonymy' %>
+    <%= render partial: "#{partials}/instance/instance_cited_by_record_within_full_synonymy",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'cited-by-relationship-instance' %>
+    <%= render partial: "#{partials}/instance/instance_cited_by_relationship_instance_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'cited-by-relationship-instance-name-only' %>
+    <%= render partial: "#{partials}/instance/instance_cited_by_relationship_instance_name_only",
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'instance-for-expansion' %>
+    <%= render partial: "#{partials}/instance/instance_for_expansion_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'Loader Batch' %>
+    <%= render partial: "#{partials}/loader_batch_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'Loader Batch in stack' %>
+    <%= render partial: "#{partials}/stack/loader_batch_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'Loader Name' %>
+    <%= render partial: "#{partials}/loader_name_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'Batch Review' %>
+    <%= render partial: "#{partials}/batch_review_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'Batch Review in stack' %>
+    <%= render partial: "#{partials}/stack/batch_review_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'Batch Reviewer' %>
+    <%= render partial: "#{partials}/batch_reviewer_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'Batch Reviewer in stack' %>
+    <%= render partial: "#{partials}/stack/batch_reviewer_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'Review Period' %>
+    <%= render partial: "#{partials}/review_period_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'Review Period in stack' %>
+    <%= render partial: "#{partials}/stack/review_period_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'BulkProcessingLog' %>
+    <%= render partial: "#{partials}/bulk_processing_log_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'User' %>
+    <%= render partial: "#{partials}/user_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'Organisation' %>
+    <%= render partial: "#{partials}/org_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'Name Review Comment' %>
+    <%= render partial: "#{partials}/main/loader/name/review/comment_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% when 'Profile::ProfileItem' %>
+    <%= render partial: "#{partials}/profile_item_record",
+      locals: {search_result: record, give_me_focus: give_me_focus} %>
+  <% else %>
+    <tr>
       <td class="width-1-percent"></td>
       <td class="min-width-40-percent width-50-percent max-width-60-percent">
-        <br> <br> <br> <br> <br>
+        <%= display_as&.to_s %> is an unknown type of standard search result
       </td>
       <td class="width-5-percent filler"></td>
     </tr>
+  <% end %>
+<% end %>
+
+<tr class="results-row-filler">
+  <td class="width-1-percent"></td>
+  <td class="min-width-40-percent width-50-percent max-width-60-percent">
+    <br> <br> <br> <br> <br>
+  </td>
+  <td class="width-5-percent filler"></td>
+</tr>
 
 

--- a/app/views/search/standard/_results.html.erb
+++ b/app/views/search/standard/_results.html.erb
@@ -11,11 +11,11 @@
 
       <% display_as = record.class.name == 'Hash' ? record[:display_as] || record.class.to_s  : record.try('display_as') || record.class.to_s %>
       <%# TODO: standardize on strings or symbols, at least for the instance record variants. %>
-      <% case display_as %>
+      <% case display_as&.to_s %>
       <% when 'Reference' %>
         <%= render partial: "#{partials}/reference_record",
           locals: {reference: record, give_me_focus: give_me_focus} %>
-      <% when :reference_as_part_of_concept %>
+      <% when 'reference_as_part_of_concept' %>
         <%= render partial: "#{partials}/reference_as_part_of_concept_record",
           locals: {reference: record, give_me_focus: give_me_focus} %>
       <% when 'Author' %>
@@ -23,16 +23,16 @@
           locals: {search_result: record, give_me_focus: give_me_focus} %>
       <% when 'Name' %>
         <%= render partial: "#{partials}/name_record", locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when :name_as_part_of_concept %>
+      <% when 'name_as_part_of_concept' %>
         <%= render partial: "#{partials}/name_as_part_of_instance_record",
           locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when :instance_as_part_of_concept %>
+      <% when 'instance_as_part_of_concept' %>
         <%= render partial: "#{partials}/instance/instance_as_part_of_concept_record",
           locals: {search_result: record, give_me_focus: give_me_focus}%>
-      <% when :citing_instance_within_name_search %>
+      <% when 'citing_instance_within_name_search' %>
         <%= render partial: "#{partials}/instance/citing_instance_within_name_search_record",
           locals: {search_result: record, give_me_focus: give_me_focus}%>
-      <% when :instance_within_reference %>
+      <% when 'instance_within_reference' %>
         <%= render partial: "#{partials}/instance/instance_within_reference_record",
           locals: {search_result: record, give_me_focus: give_me_focus}%>
       <% when 'Instance' %>
@@ -107,17 +107,17 @@
       <% else %>
         <tr>
           <td class="width-1-percent"></td>
-          <td class="min-with-40-percent width-50-percent max-width-60-percent">
-            <%= display_as %> is an unknown type of standard search result
+          <td class="min-width-40-percent width-50-percent max-width-60-percent">
+            <%= display_as&.to_s %> is an unknown type of standard search result
           </td>
-          <td class="width-5-perent filler"></td>
+          <td class="width-5-percent filler"></td>
         </tr>
       <% end %>
     <% end %>
 
     <tr class="results-row-filler">
       <td class="width-1-percent"></td>
-      <td class="min-with-40-percent width-50-percent max-width-60-percent">
+      <td class="min-width-40-percent width-50-percent max-width-60-percent">
         <br> <br> <br> <br> <br>
       </td>
       <td class="width-5-percent filler"></td>

--- a/app/views/search/wide/_results.html.erb
+++ b/app/views/search/wide/_results.html.erb
@@ -1,119 +1,115 @@
-      <caption class="hidden">Results of the latest search</caption>
-      <% @focus_anchor_id = params[:focus] unless params[:focus].blank? %>            
-    <% for record in @search.executed_query.results %><%# Allow for hashes or ActiveRecords, so use hash key syntax. %>
-      <% if record[:anchor_id] == @focus_anchor_id %>
-        <% give_me_focus = true  %>
-        <%  @focus_anchor_id = 'do not use again'  %>
-      <% else %>
-       <% give_me_focus = false %>
-      <% end %>
+  <caption class="hidden">Results of the latest search</caption>
+  <% focus_anchor_id = params[:focus].presence %>
+  <% focus_claimed = false %>
 
-      <% display_as = record.class.name == 'Hash' ? record[:display_as] || record.class.to_s  : record.try('display_as') || record.class.to_s %>
-      <%# TODO: standardize on strings or symbols, at least for the instance record variants. %>
-      <% case display_as %>
-      <% when 'Reference' %>  
-        <%= render partial: 'reference_record', 
-          locals: {reference: record, give_me_focus: give_me_focus} %>
-      <% when :reference_as_part_of_concept %>
-        <%= render partial: 'reference_as_part_of_concept_record', 
-          locals: {reference: record, give_me_focus: give_me_focus} %>
-      <% when 'Author' %>
-        <%= render partial: 'author_record', 
+  <% for record in @search.executed_query&.results || [] %><%# Allow for hashes or ActiveRecords, so use hash key syntax. %>
+    <% give_me_focus = !focus_claimed && record[:anchor_id] == focus_anchor_id %>
+    <% focus_claimed = true if give_me_focus %>
+
+    <% display_as = record.class.name == 'Hash' ? record[:display_as] || record.class.to_s  : record.try('display_as') || record.class.to_s %>
+    <%# TODO: standardize on strings or symbols, at least for the instance record variants. %>
+    <% case display_as&.to_s %>
+    <% when 'Reference' %>
+      <%= render partial: 'reference_record',
+        locals: {reference: record, give_me_focus: give_me_focus} %>
+    <% when :reference_as_part_of_concept %>
+      <%= render partial: 'reference_as_part_of_concept_record',
+        locals: {reference: record, give_me_focus: give_me_focus} %>
+    <% when 'Author' %>
+      <%= render partial: 'author_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'Name' %>
+      <%= render partial: 'name_record', locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when :name_as_part_of_concept %>
+      <%= render partial: 'name_as_part_of_instance_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when :instance_as_part_of_concept %>
+      <%= render partial: 'instance_as_part_of_concept_record',
+        locals: {search_result: record, give_me_focus: give_me_focus}%>
+    <% when :citing_instance_within_name_search %>
+      <%= render partial: 'citing_instance_within_name_search_record',
+        locals: {search_result: record, give_me_focus: give_me_focus}%>
+    <% when :instance_within_reference %>
+      <%= render partial: 'instance_within_reference_record',
+        locals: {search_result: record, give_me_focus: give_me_focus}%>
+    <% when 'Instance' %>
+      <%= render partial: 'instance_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'cites-this-instance' %>
+      <%= render partial: 'instance_cites_this_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'name-cited-by-instance' %>
+      <%= render partial: 'instance_cited_by_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'instance-is-cited-by' %>
+      <%= render partial: 'instance_is_cited_by',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'cited-by-instance' %>
+      <%= render partial: 'cited_by_instance',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'cited-by-instance-within-full-synonymy' %>
+      <%= render partial: 'instance_cited_by_record_within_full_synonymy',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'cited-by-relationship-instance' %>
+      <%= render partial: 'instance_cited_by_relationship_instance_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'cited-by-relationship-instance-name-only' %>
+        <%= render partial: 'instance_cited_by_relationship_instance_name_only',
           locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Name' %>
-        <%= render partial: 'name_record', locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when :name_as_part_of_concept %>
-        <%= render partial: 'name_as_part_of_instance_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when :instance_as_part_of_concept %>
-        <%= render partial: 'instance_as_part_of_concept_record',
-          locals: {search_result: record, give_me_focus: give_me_focus}%>
-      <% when :citing_instance_within_name_search %>
-        <%= render partial: 'citing_instance_within_name_search_record',
-          locals: {search_result: record, give_me_focus: give_me_focus}%>
-      <% when :instance_within_reference %>
-        <%= render partial: 'instance_within_reference_record',
-          locals: {search_result: record, give_me_focus: give_me_focus}%>
-      <% when 'Instance' %>
-        <%= render partial: 'instance_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'cites-this-instance' %>
-        <%= render partial: 'instance_cites_this_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'name-cited-by-instance' %>
-        <%= render partial: 'instance_cited_by_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'instance-is-cited-by' %>
-        <%= render partial: 'instance_is_cited_by',
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'cited-by-instance' %>  
-        <%= render partial: 'cited_by_instance', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'cited-by-instance-within-full-synonymy' %>  
-        <%= render partial: 'instance_cited_by_record_within_full_synonymy', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-     <% when 'cited-by-relationship-instance' %>  
-        <%= render partial: 'instance_cited_by_relationship_instance_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'cited-by-relationship-instance-name-only' %>  
-         <%= render partial: 'instance_cited_by_relationship_instance_name_only', 
-           locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'instance-for-expansion' %>  
-        <%= render partial: 'instance_for_expansion_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Loader Batch' %>  
-        <%= render partial: 'application/search_results/loader_batch_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Loader Batch in stack' %>  
-        <%= render partial: 'application/search_results/stack/loader_batch_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Loader Name' %>  
-        <%= render partial: 'application/search_results/loader_name_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Batch Review' %>  
-        <%= render partial: 'application/search_results/batch_review_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Batch Review in stack' %>  
-        <%= render partial: 'application/search_results/stack/batch_review_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Batch Reviewer' %>  
-        <%= render partial: 'application/search_results/batch_reviewer_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Batch Reviewer in stack' %>  
-        <%= render partial: 'application/search_results/stack/batch_reviewer_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Review Period' %>  
-        <%= render partial: 'application/search_results/review_period_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Review Period in stack' %>  
-        <%= render partial: 'application/search_results/stack/review_period_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'BulkProcessingLog' %>  
-        <%= render partial: 'application/search_results/bulk_processing_log_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'User' %>  
-        <%= render partial: 'application/search_results/user_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% when 'Organisation' %>  
-        <%= render partial: 'application/search_results/org_record', 
-          locals: {search_result: record, give_me_focus: give_me_focus} %>
-      <% else %>
-        <tr>
-          <td class="width-1-percent"></td>
-          <td class="min-with-40-percent width-50-percent max-width-60-percent">
-            <%= display_as %> is an unknown type of wide search result
-          </td>
-          <td class="width-5-perent filler"></td>
-        </tr>
-      <% end %>
+    <% when 'instance-for-expansion' %>
+      <%= render partial: 'instance_for_expansion_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'Loader Batch' %>
+      <%= render partial: 'application/search_results/loader_batch_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'Loader Batch in stack' %>
+      <%= render partial: 'application/search_results/stack/loader_batch_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'Loader Name' %>
+      <%= render partial: 'application/search_results/loader_name_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'Batch Review' %>
+      <%= render partial: 'application/search_results/batch_review_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'Batch Review in stack' %>
+      <%= render partial: 'application/search_results/stack/batch_review_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'Batch Reviewer' %>
+      <%= render partial: 'application/search_results/batch_reviewer_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'Batch Reviewer in stack' %>
+      <%= render partial: 'application/search_results/stack/batch_reviewer_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'Review Period' %>
+      <%= render partial: 'application/search_results/review_period_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'Review Period in stack' %>
+      <%= render partial: 'application/search_results/stack/review_period_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'BulkProcessingLog' %>
+      <%= render partial: 'application/search_results/bulk_processing_log_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'User' %>
+      <%= render partial: 'application/search_results/user_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% when 'Organisation' %>
+      <%= render partial: 'application/search_results/org_record',
+        locals: {search_result: record, give_me_focus: give_me_focus} %>
+    <% else %>
+      <tr>
+        <td class="width-1-percent"></td>
+        <td class="min-with-40-percent width-50-percent max-width-60-percent">
+          <%= display_as %> is an unknown type of wide search result
+        </td>
+        <td class="width-5-perent filler"></td>
+      </tr>
     <% end %>
+  <% end %>
 
-    <tr>
-      <td class="width-1-percent"></td>
-      <td class="min-with-40-percent width-50-percent max-width-60-percent">
-        <br> <br> <br> <br> <br>
-      </td>
-      <td class="width-5-percent filler"></td>
-    </tr>
-
-
+  <tr>
+    <td class="width-1-percent"></td>
+    <td class="min-with-40-percent width-50-percent max-width-60-percent">
+      <br> <br> <br> <br> <br>
+    </td>
+    <td class="width-5-percent filler"></td>
+  </tr>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 09-July-2026
+  :jira_id: '5708'
+  :description: |-
+    Fixup typos in the search results as suggested by claude
+- :date: 09-July-2026
   :jira_id: '4602'
   :description: |-
     Tree Element Profile Editing: Improve error handling on the Edit Profile tab

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.32
+appversion=5.1.4.33


### PR DESCRIPTION
## Description
- Fixup typos suggested by claude
- Fixup indentations and remove extra white spaces
- Updated the other results templates from /review and /wide

## Type of change
Please delete options that are not relevant.
- [x] Improvement

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
