### PR TITLE
NSL-4602: Tree Element Profile Editing: Improve error handling on the Edit Profile tab

### DIFF
--- a/app/models/concerns/tree/element/profile.rb
+++ b/app/models/concerns/tree/element/profile.rb
@@ -79,7 +79,8 @@ module Tree::Element::Profile
     message = ""
     refresh = false
     if excluded?
-      message = "We don't allow changes to distribution for excluded taxa"
+      message = "Error: We don't allow changes to distribution for excluded taxa"
+      raise message
     else
       message, refresh =
         transaction_for_update_accepted_distribution(dist_param, username)
@@ -95,9 +96,7 @@ module Tree::Element::Profile
     rescue StandardError => e
       Rails.logger.error("Rolling back transaction in update_distribution")
       Rails.logger.error(e.to_s)
-      message = "Error: #{e}"
-      refresh = false
-      raise ActiveRecord::Rollback
+      raise
     end
     [message, refresh]
   end

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 09-July-2026
+  :jira_id: '4602'
+  :description: |-
+    Tree Element Profile Editing: Improve error handling on the Edit Profile tab
+- :date: 09-July-2026
   :jira_id: '5845'
   :description: |-
     Additional css fixes for bs5 addressing feedback from testing

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.30
+appversion=5.1.4.31

--- a/test/controllers/tree/elements_controller_test.rb
+++ b/test/controllers/tree/elements_controller_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Tree::ElementsController#update_profile.
+#
+# A raised error while updating the distribution part of the profile (e.g.
+# an excluded taxon, or an invalid distribution value) must short-circuit
+# the whole action: render the error view with 422, and leave any pending
+# comment change unapplied - see app/models/concerns/tree/element/profile.rb.
+class TreeElementsControllerTest < ActionController::TestCase
+  tests Tree::ElementsController
+
+  def valid_session
+    { username: "fred", user_full_name: "Fred Jones", groups: %w[edit treebuilder] }
+  end
+
+  test "distribution error on an excluded taxon renders the error view and skips the comment update" do
+    trel = tree_elements(:red_gum_in_taxonomy)
+    trel.update_column(:excluded, true)
+    assert_nil(trel.comment_value, "Expect no comment to start this test")
+
+    @request.headers["Accept"] = "application/javascript"
+    patch(:update_profile,
+          params: { id: trel.id,
+                    tree_element: { distribution_value: "WA, NSW",
+                                    comment_value: "should not be applied" } },
+          session: valid_session)
+
+    assert_response :unprocessable_content
+    assert_template "update_profile_error"
+    assert_match(/Distribution update error:.*excluded taxa/i, assigns(:message))
+    assert_nil(assigns(:comment_message),
+               "Comment should never have been processed")
+
+    te_unchanged = Tree::Element.find(trel.id)
+    assert_nil(te_unchanged.comment_value,
+               "Expected comment to be unchanged when the distribution update errors")
+  end
+
+  test "a normal distribution and comment update succeeds" do
+    trel = tree_elements(:red_gum_in_taxonomy)
+    assert_nil(trel.profile, "Expect no profile to start this test")
+
+    @request.headers["Accept"] = "application/javascript"
+    patch(:update_profile,
+          params: { id: trel.id,
+                    tree_element: { distribution_value: "NSW, WA",
+                                    comment_value: "a new comment" } },
+          session: valid_session)
+
+    assert_response :success
+    assert_template "update_profile"
+    assert_match(/Distribution added/i, assigns(:distribution_message))
+    assert_match(/Comment added/i, assigns(:comment_message))
+
+    te_changed = Tree::Element.find(trel.id)
+    assert_equal("a new comment", te_changed.comment_value)
+    assert_not_nil(te_changed.distribution_value)
+  end
+end

--- a/test/models/tree/element/profile/distribution/excluded_taxa_test.rb
+++ b/test/models/tree/element/profile/distribution/excluded_taxa_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Distribution cannot be changed for an excluded taxon - update_distribution
+# should raise rather than silently continuing (see also
+# app/models/concerns/tree/element/profile.rb#update_distribution).
+class ExcludedTaxaTest < ActiveSupport::TestCase
+  test "cannot update distribution for an excluded taxon" do
+    trel = tree_elements(:red_gum_in_taxonomy)
+    trel.excluded = true
+    assert_nil(trel.distribution_value, "Expect no distribution to start this test")
+
+    error = assert_raises(RuntimeError) do
+      trel.update_distribution("WA, NSW", "dist user")
+    end
+
+    assert_match(/We don't allow changes to distribution for excluded taxa/i,
+                 error.message,
+                 "Unexpected message for an excluded taxon distribution update")
+
+    te_unchanged = Tree::Element.find(trel.id)
+    assert_nil(te_unchanged.distribution_value,
+               "Expected distribution to be unchanged for an excluded taxon")
+  end
+end

--- a/test/models/tree/element/profile/distribution/invalid_distribution_test.rb
+++ b/test/models/tree/element/profile/distribution/invalid_distribution_test.rb
@@ -13,23 +13,24 @@ class InvalidDistributionTest < ActiveSupport::TestCase
     trel = update_profile_to_invalid_dist(
       trel,
       "Vic,, NSW",
-      /Error: empty distribution value, likely due to an unnecessary comma/i
+      /empty distribution value, likely due to an unnecessary comma/i
     )
     update_profile_to_invalid_dist(
       trel,
       ",Vic",
-      /Error: empty distribution value, likely due to an unnecessary comma/i
+      /empty distribution value, likely due to an unnecessary comma/i
     )
   end
 
-  def update_profile_to_invalid_dist(trel, new_dist, expected_message_re = /Error: Invalid distribution value: /i)
+  def update_profile_to_invalid_dist(trel, new_dist, expected_message_re = /Invalid distribution value: /i)
     tag = "update_profile_to_invalid_dist"
-    message, refresh = trel.update_distribution(new_dist, "dist user")
-    te_changed = Tree::Element.find(trel.id)
+    error = assert_raises(RuntimeError) do
+      trel.update_distribution(new_dist, "dist user")
+    end
     assert_match(expected_message_re,
-                 message,
+                 error.message,
                  "Unexpected message for #{tag} with dist: #{new_dist}")
-    assert_not(refresh, "Expected no refresh for #{tag}")
+    te_changed = Tree::Element.find(trel.id)
     assert_nil(te_changed.distribution_value,
                "Expected distribution to be unchanged for #{tag}")
     te_changed


### PR DESCRIPTION
## Description
Claude's summary: 
 
Core fix — `app/models/concerns/tree/element/profile.rb`: distribution-update failures now raise real exceptions instead of returning an error message string that the caller could silently ignore. 

An excluded-taxon attempt raises immediately ("Error: We don't allow changes to distribution for excluded taxa"), and `transaction_for_update_accepted_distribution` re-raises whatever the validation layer threw (invalid value, empty value from a stray comma, etc.) after letting the transaction auto-rollback, rather than swallowing it into a message string. 

Net effect: `Tree::ElementsController#update_profile` now correctly falls into its rescue `StandardError` block for these cases — rendering the error view with 422 and skipping the comment update — instead of quietly continuing as if the request had succeeded

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
See Jira

## Tests
- [x] Unit tests (thanks Claude - adjusted existing and added new)
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
