### PR TITLE
NSL-5806:  Loader Name Search: add new "any-batch" target and remove the default to "any-batch"

### DIFF
--- a/app/models/search/empty_parsed_request.rb
+++ b/app/models/search/empty_parsed_request.rb
@@ -33,6 +33,8 @@ class Search::EmptyParsedRequest
               :target_table,
               :where_arguments,
               :query_target,
+              :original_query_target,
+              :original_query_target_for_display,
               :target_button_text,
               :show_instances,
               :print,
@@ -43,6 +45,7 @@ class Search::EmptyParsedRequest
     @empty = true
     @defined_query = false
     @target_button_text = params[:query_target] || "Names"
+    @original_query_target_for_display = @original_query_target = params[:query_target]
     @count = false
     @list = false
     @limited = false

--- a/app/models/search/parsed_request.rb
+++ b/app/models/search/parsed_request.rb
@@ -471,8 +471,7 @@ class Search::ParsedRequest
            @params["query_string"].match(/[^-]id:/i) ||
            @params["query_string"].match(/\Aid:/i) ||
            @params["query_string"].match(/\bid-with-syn:/i) 
-      @params["query_string"] = @params["query_string"].dup << ' any-batch:'
-      @note_to_user = 'any-batch applied'
+      raise "Please set a default batch, or specify a 'batch-id:', a 'batch-name:' or 'any-batch:'"
     end
   end
 

--- a/app/models/search/parsed_request.rb
+++ b/app/models/search/parsed_request.rb
@@ -81,6 +81,7 @@ class Search::ParsedRequest
     "batch_stacks" => "batch stack",
     "loader_name" => "loader name",
     "loader_names" => "loader name",
+    "loader_names_any_batch" => "loader name",
     "batch_review" => "batch review",
     "batch_reviews" => "batch review",
     "batch_review_period" => "batch review period",
@@ -182,6 +183,7 @@ class Search::ParsedRequest
 
   PREPROCESSING_TARGETS = {
     "loader_names" => "preprocess_loader_names",
+    "loader_names_any_batch" => "preprocess_loader_names_any_batch",
   }
 
   SHOW_INSTANCES = "show-instances:"
@@ -192,11 +194,11 @@ class Search::ParsedRequest
   def initialize(params)
     @params = params
     @note_to_user = ''
+    @original_query_target_for_display = params[:query_target]
     @query_string = canonical_query_string
     @query_string = @query_string.gsub(/  */, " ") unless @query_string.blank?
-    @query_target = (@params["canonical_query_target"] || "").strip.downcase
+    @query_target = (@params["canonical_query_target"] || "").gsub(')','').gsub('(','').strip.downcase
     @user = @params[:current_user]
-    @original_query_target = @query_target
     @default_query_scope = ""
     @apply_default_query_scope = false
     @original_query_target = @query_target
@@ -449,7 +451,7 @@ class Search::ParsedRequest
     elsif ADDITIONAL_NON_PREPROCESSED_TARGETS.include?(@query_target)
     elsif loader_batch_preprocessing?
     else
-      raise "Unknown query target, please choose one from the list."
+      raise "Unknown query target '#{@query_target}', please choose one from the list."
     end
     tokens
   end
@@ -475,6 +477,11 @@ class Search::ParsedRequest
     end
   end
 
+  def preprocess_loader_names_any_batch
+    @target_button_text = @original_query_target
+    @query_string += ' any-batch: ' unless @query_string.match(/any-batch:/)
+  end
+
   # TODO: convert this procedural code that refers to specific models to model
   # code or to some sort of declaration
   # TODO: should be in loader/name code
@@ -488,8 +495,8 @@ class Search::ParsedRequest
        end.include?(@query_target.downcase.gsub("_", " ").rstrip)
       @default_query_scope = "batch-id: #{::Loader::Batch.id_of(@query_target.gsub('_', ' '))}"
       debug("here is @default_query_scope: #{@default_query_scope}")
-      @target_button_text = @query_target
       @original_query_target = @query_target
+      @target_button_text = @query_target
       @query_target = "loader_names"
       @apply_default_query_scope = true
       true
@@ -503,8 +510,6 @@ class Search::ParsedRequest
       raise "Cannot parse target: #{@query_target}." unless SIMPLE_QUERY_TARGETS.key?(@query_target)
 
       @target_table = SIMPLE_QUERY_TARGETS[@query_target]
-      @target_button_text = @target_table.capitalize.pluralize
-      @original_query_target_for_display = @original_query_target.gsub("_", " ").capitalize
       @target_model = TARGET_MODELS[@target_table]
       @default_order_column = DEFAULT_ORDER_COLUMNS[@target_table]
       @default_query_directive = DEFAULT_QUERY_DIRECTIVES[@target_table]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -94,7 +94,7 @@ input[type="checkbox"]:not([title]) {
     <div id="main-content" class="container-fluid">
 
     <% wide_details =  '' %>
-    <% wide_details = 'wide-details' if params[:query_target]&.downcase == 'loader names' && @view_mode == ViewMode::STANDARD %>
+    <% wide_details = 'wide-details' if params[:query_target]&.downcase =~ /loader.names/ && @view_mode == ViewMode::STANDARD %>
     <div id="search-result-details" class="hidden <%= wide_details %>"> </div>
 
       <div class="row">

--- a/app/views/loader/names/help/_fields.html.erb
+++ b/app/views/loader/names/help/_fields.html.erb
@@ -3,7 +3,6 @@
   <p>Note: setting a default batch will apply that batch to Loader Name searches.
   <p>Note: when searching for loader-names you need to specify a batch via 'batch-id:', 'batch-name:', or by setting a default batch.  If you really want to search across batches use the 'any-batch:' directive.
   <tr><th>Field</th><th>Description</th></tr>
-  <p>Note: In January 2026 we made "any-batch:" the default - so, with no batch selected as a default, your loader name queries will behave as if you had added the "any-batch:" directive
   <% [
     {field_name: 'batch-id:', descr: "Search within a batch using its ID."},
     {field_name: 'batch-name:', descr: "Search within a batch using its name. Accepts wild-cards."},

--- a/app/views/search/_search_form.html.erb
+++ b/app/views/search/_search_form.html.erb
@@ -23,11 +23,13 @@
 
       <input id="query-submit" name="query_submit" value="Search <%= Rails.configuration.database_configuration[Rails.env]['database'].upcase %>"
              type="submit" class="btn search-btn" tabindex="9" title="Run the query">
+      <input id="query-target" name="query_target" 
+             value="<%= @search.parsed_request.try('original_query_target_for_display') ||
+                        @search.parsed_request.try('target_button_text') || 'Names' %>" type="hidden" >
     </div><!-- /input-group -->
   </div><!-- /.col-lg-9 -->
 </div><!-- /row -->
 
-  <input id="query-target" name="query_target" value="<%= @search.parsed_request.target_button_text %>" type="hidden" >
   <input id="focus_id" name="focus_id" type="hidden" value="<%= @focus_id %>" class="pull-right" title="focus id">
 
 <% end %>

--- a/app/views/search/_search_target.html.erb
+++ b/app/views/search/_search_target.html.erb
@@ -8,7 +8,9 @@
                 aria-haspopup="true" 
                 aria-expanded="false">
           <span id="search-target-button-text">
-                <%= (@search.parsed_request.target_button_text.gsub(/_/,' ') || 'no target button text') unless @search.nil? %>
+                <%= (@search.parsed_request.original_query_target_for_display ||
+                     @search.parsed_request.target_button_text  ||
+                     'no target button text') unless @search.nil? %>
 
 
           </span>

--- a/app/views/search/search_targets/_standard_targets.html.erb
+++ b/app/views/search/search_targets/_standard_targets.html.erb
@@ -23,6 +23,13 @@
                    data-examples="loader-name-search-examples"
                 >Loader names</a>
             </li>
+            <li><a id="search-target-item-loader-name-any-batch"
+                   href="#"
+                   title="Search loader names across any batch"
+                   data-help="loader-name-search-help"
+                   data-examples="loader-name-search-examples"
+                >Loader names (any batch)</a>
+            </li>
           <% end %>
 
           <li role="separator" class="divider"></li>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,11 @@
+- :date: 10-July-2026
+  :jira_id: '5806'
+  :description: |-
+    Loader Name Search: add new "any-batch" target and remove the default to "any-batch"
+- :date: 09-July-2026
+  :jira_id: '5708'
+  :description: |-
+    Fixup typos in the search results as suggested by claude
 - :date: 09-July-2026
   :jira_id: '5708'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.33
+appversion=5.1.4.34

--- a/test/controllers/search/loader/names/any_batch_target_test.rb
+++ b/test/controllers/search/loader/names/any_batch_target_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single search controller test.
+#
+# Exercises the new "Loader names (any batch)" search target - a distinct
+# dropdown item that explicitly searches across all batches, alongside the
+# plain "Loader names" target. The browser submits the link's literal text
+# as query_target, e.g. "Loader names (any batch)", which Search::Base
+# canonicalizes to "loader_names_(any_batch)" before ParsedRequest strips
+# the parens down to "loader_names_any_batch".
+class SearchLoaderNameAnyBatchTargetTest < ActionController::TestCase
+  tests SearchController
+
+  test "loader names (any batch) target does not require a default batch" do
+    get(:search,
+        params: { query_target: "loader names (any batch)", query_string: "*" },
+        session: { username: "fred",
+                   user_full_name: "Fred Jones",
+                   groups: [:login, :"batch-loader"] })
+    assert_response :success
+    assert_not_select "#search-results-summary",
+                       /Please set a default batch/,
+                       "Should not be asked to set a default batch"
+  end
+
+  test "loader names (any batch) target searches across batches without an explicit any-batch directive" do
+    get(:search,
+        params: { query_target: "loader names (any batch)", query_string: "Hardenbergia violacea" },
+        session: { username: "fred",
+                   user_full_name: "Fred Jones",
+                   groups: [:login, :"batch-loader"] })
+    assert_response :success
+    assert_select "#search-results-summary",
+                  /\b1 record*\b/,
+                  "Should find one loader name record for Hardenbergia violacea across all batches"
+  end
+end

--- a/test/controllers/search/loader/names/no_default_batch_test.rb
+++ b/test/controllers/search/loader/names/no_default_batch_test.rb
@@ -22,15 +22,15 @@ require "test_helper"
 class SearchLoaderNameNoDefaultBatchTest < ActionController::TestCase
   tests SearchController
 
-  test "can search for loader names" do
+  test "search for loader names needs a default batch" do
     get(:search,
         params: { query_target: "loader names", query_string: "*"},
         session: { username: "fred",
                    user_full_name: "Fred Jones",
                    groups: [:login, :"batch-loader"] })
     assert_response :success
-    assert_not_select "#search-results-summary",
+    assert_select "#search-results-summary",
                   /Please set a default batch/,
-                  "Should not be asked to set a default batch"
+                  "Should be asked to set a default batch"
   end
 end

--- a/test/controllers/search/loader/names/with_invalid_default_batch_and_limit_test.rb
+++ b/test/controllers/search/loader/names/with_invalid_default_batch_and_limit_test.rb
@@ -29,9 +29,9 @@ class SearchLoaderNameInvalidDefaultBatchAndLimitTest < ActionController::TestCa
                    user_full_name: "Fred Jones",
                    groups: [:login, :"batch-loader"] })
     assert_response :success
-    assert_not_select "#search-results-summary",
-                      /Please set a default batch/,
-                     "Should NOT be asked to set a default batch"
+    assert_select "#search-results-summary",
+                  /Please set a default batch/,
+                  "Should be asked to set a default batch"
     
     qs_field_value = css_select("#query-string-field[value]")
     assert_match /Hardenbergia violacea *limit: 10/, qs_field_value.to_s,

--- a/test/controllers/search/loader/names/with_invalid_default_batch_test.rb
+++ b/test/controllers/search/loader/names/with_invalid_default_batch_test.rb
@@ -29,8 +29,8 @@ class SearchLoaderNameWithInvalidDefaultBatchTest < ActionController::TestCase
                    user_full_name: "Fred Jones",
                    groups: [:login, :"batch-loader"] })
     assert_response :success
-    assert_not_select "#search-results-summary",
+    assert_select "#search-results-summary",
                   /Please set a default batch/,
-                  "Should not be asked to set a default batch"
+                  "Should be asked to set a default batch"
   end
 end

--- a/test/controllers/search/targets/lower_case_target_test.rb
+++ b/test/controllers/search/targets/lower_case_target_test.rb
@@ -28,7 +28,7 @@ class SearchControllerLowerCaseTargetTest < ActionController::TestCase
         session: { username: "fred",
                    user_full_name: "Fred Jones",
                    groups: [:edit, :taxonomic_review, :login] })
-    assert_select 'span#search-target-button-text', /Names/, "The input search target 'name' should be output as canonical 'Names'"
+    assert_select 'span#search-target-button-text', /name/, "The input search target 'name' should be output as 'name'"
     assert_response :success
   end
 end

--- a/test/models/search/loader/name/simple_with_xany_batch_test.rb
+++ b/test/models/search/loader/name/simple_with_xany_batch_test.rb
@@ -33,6 +33,7 @@ class SearchLoaderNameWithXanyBatchTest < ActiveSupport::TestCase
     error = assert_raises(RuntimeError) do
       Search::Base.new(params)
     end
-    assert_match(/Cannot search this target for: xany-batch:/i, error.message)
+    assert_match(/Please set a default batch, or specify a/i, error.message)
+    assert_match(/'batch-id:', a 'batch-name:' or 'any-batch:'/i, error.message)
   end
 end

--- a/test/models/search/loader/name/simple_with_xbatch_id_test.rb
+++ b/test/models/search/loader/name/simple_with_xbatch_id_test.rb
@@ -36,6 +36,7 @@ class SearchLoaderNameWithXBatchIdTest < ActiveSupport::TestCase
     error = assert_raises(RuntimeError) do
       Search::Base.new(params)
     end
-    assert_match(/Cannot search this target for: xbatch-id:/i, error.message)
+    assert_match(/Please set a default batch, or specify a/i, error.message)
+    assert_match(/'batch-id:', a 'batch-name:' or 'any-batch:'/i, error.message)
   end
 end

--- a/test/models/search/loader/name/simple_without_any_batch_ident_test.rb
+++ b/test/models/search/loader/name/simple_without_any_batch_ident_test.rb
@@ -29,11 +29,13 @@ class SearchLoaderNameWithoutAnyBatchIdentTest < ActiveSupport::TestCase
                                                           "*",
                                                           current_user:
                                                           build_edit_user)
-    search = Search::Base.new(params)
-    assert search.executed_query.results.is_a?(ActiveRecord::Relation),
-           "Results should be an ActiveRecord::Relation."
-    assert_equal 3,
-                 search.executed_query.results.size,
-                 "Exactly 3 results are expected."
+    # TODO: rails 7.1 has a better way
+    # https://blog.saeloun.com/2023/07/17/
+    # add-ability-to-match-exception-messages-to-assert-raises-assertion/
+    error = assert_raises(RuntimeError) do
+      Search::Base.new(params)
+    end
+    assert_match(/Please set a default batch, or specify a/i, error.message)
+    assert_match(/'batch-id:', a 'batch-name:' or 'any-batch:'/i, error.message)
   end
 end


### PR DESCRIPTION
## Description
A loader-name search no longer silently scans every batch by accident — the user must either pick a batch, type any-batch: themselves, or click the new dedicated "any batch" target, which was the missing piece needed to make the rollback usable day-to-day.

## Type of change
- [x] New feature  - will stop some old searches working if users have bookmarked them

## How to Test
See Jira

## Tests
- [x] Unit tests - with help from Claude
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
