### PR TITLE
NSL-3117: Name: stop users creating autonym names of ineligible ranks

### DIFF
--- a/app/models/concerns/name_validatable.rb
+++ b/app/models/concerns/name_validatable.rb
@@ -77,7 +77,7 @@ module NameValidatable
     return unless name_type.autonym?
     return if name_rank.compatible_with_autonym?
 
-    errors.add(:name_type_id, "autonym cannot be this rank")
+    errors.add(:name_type_id, "autonym must either be infrageneric or infraspecific rank")
   end
 
   def genus_parent_must_match_family_if_both_ranked_family

--- a/app/models/name_type.rb
+++ b/app/models/name_type.rb
@@ -117,6 +117,14 @@ class NameType < ApplicationRecord
     end
   end
 
+  def self.scientific_family_or_above
+    where(scientific: true)
+      .where(" (not hybrid or name in ('named hybrid autonym'))")
+      .where(" name != 'phrase name' ")
+      .where("name != 'autonym'")
+      .sort_by(&:name).collect { |n| [n.name, n.id] }
+  end
+
   def self.scientific_1_parent_options
     where(scientific: true)
       .where(" (not hybrid or name in ('named hybrid autonym'))")

--- a/app/views/names/form/_name_type.html.erb
+++ b/app/views/names/form/_name_type.html.erb
@@ -3,6 +3,8 @@
     <%
       name_type_options = if can?(:create_common_name, Name) && !can?(:manage, Name) && @name.category_for_edit.other?
                             NameType.common_only_options
+                          elsif @category =~ /scientific.family.or.above/i
+                            NameType.scientific_family_or_above
                           else
                             NameType.options_for_category(@name.category_for_edit)
                           end

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 13-July-2026
+  :jira_id: '3117'
+  :description: |-
+    Name: stop users creating autonym names of ineligible ranks
 - :date: 10-July-2026
   :jira_id: '5806'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.34
+appversion=5.1.4.35

--- a/test/models/name/validations/autonym/name_type_autonym_for_restricted_ranks_only_test.rb
+++ b/test/models/name/validations/autonym/name_type_autonym_for_restricted_ranks_only_test.rb
@@ -27,7 +27,7 @@ require "test_helper"
 #
 # Non-autonym name types are unaffected by this validation.
 class NameTypeAutonymForRestrictedRanksOnlyTest < ActiveSupport::TestCase
-  ERROR = "Name type autonym cannot be this rank"
+  ERROR = "Name type autonym must either be infrageneric or infraspecific rank"
 
   def autonym
     names(:autonym_for_rank_validation)

--- a/test/models/name_type/scientific_family_or_above_test.rb
+++ b/test/models/name_type/scientific_family_or_above_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# NameType.scientific_family_or_above is used to populate the Type dropdown
+# when adding a new scientific name at family rank or above. It should
+# behave like NameType.scientific_1_parent_options, except that 'autonym'
+# is never offered - autonyms can only exist at infrageneric or
+# infraspecific ranks (see NameRank#compatible_with_autonym?), never at
+# family or above.
+class ScientificFamilyOrAboveTest < ActiveSupport::TestCase
+  test "scientific family or above name type options" do
+    part1
+    part2
+    part3
+  end
+
+  def part1
+    assert_equal 3,
+                 NameType.scientific_family_or_above.size,
+                 "Should be 3 scientific-family-or-above name types."
+  end
+
+  def part2
+    names = NameType.scientific_family_or_above.collect(&:first)
+    assert names.include?("scientific"),
+           "'scientific' should be a scientific-family-or-above name type."
+    assert names.include?("sanctioned"),
+           "'sanctioned' should be a scientific-family-or-above name type."
+    assert names.include?("named hybrid autonym"),
+           "'named hybrid autonym' should be a scientific-family-or-above " \
+           "name type."
+  end
+
+  def part3
+    names = NameType.scientific_family_or_above.collect(&:first)
+    assert_not names.include?("autonym"),
+               "'autonym' should NOT be a scientific-family-or-above " \
+               "name type - it's invalid at family rank and above."
+    assert_not names.include?("phrase name"),
+               "'phrase name' should NOT be a scientific-family-or-above " \
+               "name type."
+    assert_not names.include?("named hybrid"),
+               "'named hybrid' should NOT be a scientific-family-or-above " \
+               "name type (it's a hybrid, not the named-hybrid-autonym " \
+               "exception)."
+    assert_not names.include?("hybrid formula parents known"),
+               "'hybrid formula parents known' should NOT be a " \
+               "scientific-family-or-above name type."
+  end
+end


### PR DESCRIPTION
## Description
Change validation message and offer a restricted drop-down list on a form.  See JIra for more details

## Type of change
- [x] Bug fix or tightening up of validations

## How to Test
See Jira

## Tests
- [x] Unit tests - from Claude
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
