### PR TITLE
NSL-3228: Name Delete: Reduce length of extra reason field to 200 char

### DIFF
--- a/app/models/names_delete.rb
+++ b/app/models/names_delete.rb
@@ -40,7 +40,7 @@ class NamesDelete < ActiveType::Object
     if extra_info.blank?
       reason
     else
-      "#{reason}; #{extra_info}"
+      "#{reason}; #{extra_info}".truncate(255)
     end
   end
 

--- a/app/views/names_deletes/_new.html.erb
+++ b/app/views/names_deletes/_new.html.erb
@@ -24,9 +24,6 @@
       class: 'btn btn-danger width-8em', 
       disabled: false %>
     <%= cancel_delete_link %>
-    <br>
-    <br>
-    <br>
     <div class="form-group">
       <label for="names_delete_reason">Reason*</label>
     <br>
@@ -42,13 +39,11 @@
     <div class="form-group">
       <label for="names_delete_extra_info">Extra information</label>
       <%= f.text_area :extra_info,
-        title: "Enter any extra information about the reason for delete. Up to 500 characters long. Field is required if you choose reason of 'Other'.", 
-        style: 'width: 100%; height: 8lh;',
-        maxlength: 500, tabindex: increment_tab_index, class: 'form-control pull-left' %>
+        title: "Enter any extra information about the reason for delete. Up to 200 characters long. Field is required if you choose reason of 'Other'.", 
+        style: 'width: 100%; height: 6lh;',
+        maxlength: 200, tabindex: increment_tab_index, class: 'form-control pull-left' %>
     </div>
-    <br>
-    <br>
-    <br>
+    <p>Up to 200 characters allowed</p>
     <p id="name-delete-spinner" class="hidden">
     Deleting...    <i class="fa fa-spinner fa-spin"></i>
     </p>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 13-July-2026
+  :jira_id: '3228'
+  :description: |-
+    Name Delete: Reduce length of extra reason field to 200 char
+- :date: 13-July-2026
   :jira_id: '5845'
   :description: |-
     Fixup tabs position for bs5

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.37
+appversion=5.1.4.38

--- a/test/models/names_delete/assembled_reason_test.rb
+++ b/test/models/names_delete/assembled_reason_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# NamesDelete#assembled_reason joins reason and extra_info together and is
+# what actually gets sent (URL-encoded) to the external delete service via
+# Name::AsServices#delete_with_reason. It must never exceed 255 characters,
+# regardless of how the two pieces combine - the UI's own maxlength on
+# extra_info (200) is only a soft guard, this is the hard one.
+class NamesDeleteAssembledReasonTest < ActiveSupport::TestCase
+  LONGEST_PRESET_REASON = "Name is an autonym that has not yet been established"
+
+  def name_id
+    names(:scientific_name).id
+  end
+
+  test "assembled reason is just the reason when extra_info is blank" do
+    names_delete = NamesDelete.new(name_id: name_id,
+                                    reason: "Name does not exist",
+                                    extra_info: "")
+    assert_equal "Name does not exist", names_delete.assembled_reason
+  end
+
+  test "assembled reason joins reason and extra_info with a semicolon" do
+    names_delete = NamesDelete.new(name_id: name_id,
+                                    reason: "Other",
+                                    extra_info: "Duplicate of another name")
+    assert_equal "Other; Duplicate of another name",
+                 names_delete.assembled_reason
+  end
+
+  test "assembled reason is untouched at exactly 255 characters" do
+    reason = "Other"
+    extra_info = "X" * (255 - "#{reason}; ".length)
+    names_delete = NamesDelete.new(name_id: name_id,
+                                    reason: reason,
+                                    extra_info: extra_info)
+    result = names_delete.assembled_reason
+    assert_equal 255, result.length
+    assert_not result.end_with?("..."),
+               "Should not be truncated at exactly 255 characters"
+    assert_equal "#{reason}; #{extra_info}", result
+  end
+
+  test "assembled reason is truncated to 255 characters when over the limit" do
+    reason = "Other"
+    extra_info = "X" * 300
+    names_delete = NamesDelete.new(name_id: name_id,
+                                    reason: reason,
+                                    extra_info: extra_info)
+    result = names_delete.assembled_reason
+    assert_equal 255, result.length
+    assert result.end_with?("..."), "Should be truncated with an ellipsis"
+    assert result.start_with?("#{reason}; "),
+           "Truncation should preserve the reason at the start"
+  end
+
+  test "assembled reason stays within 255 chars even with the longest " \
+       "preset reason and a full-length extra_info" do
+    extra_info = "X" * 200
+    names_delete = NamesDelete.new(name_id: name_id,
+                                    reason: LONGEST_PRESET_REASON,
+                                    extra_info: extra_info)
+    result = names_delete.assembled_reason
+    assert result.length <= 255,
+           "Combined reason + extra_info must never exceed 255 characters, " \
+           "was #{result.length}"
+  end
+end


### PR DESCRIPTION
## Description
See Jira - but allowing just enough explanatory text to avoid blowing up Services.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
See Jira

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
