### PR TITLE
NSL-5197 - Add selected_status_id method and update name status form …

### DIFF
--- a/app/models/concerns/name_enterable.rb
+++ b/app/models/concerns/name_enterable.rb
@@ -10,6 +10,13 @@ module NameEnterable
     NameStatus.options_for_category(category_for_edit)
   end
 
+  def selected_status_id
+    return name_status_id unless category_for_edit.phrase_name?
+
+    options = status_options
+    options.first.last if options.one?
+  end
+
   def takes_name_element?
     category_for_edit.takes_name_element?
   end

--- a/app/models/concerns/name_enterable.rb
+++ b/app/models/concerns/name_enterable.rb
@@ -14,6 +14,8 @@ module NameEnterable
     return name_status_id unless category_for_edit.phrase_name?
 
     options = status_options
+
+    # options is an array of arrays, each inner array is [name, id]
     options.first.last if options.one?
   end
 

--- a/app/views/names/form/_name_status.html.erb
+++ b/app/views/names/form/_name_status.html.erb
@@ -9,11 +9,12 @@
                'name_status_id',
                @name.status_options,
                {include_blank: true,
-                prompt: ''},
+                prompt: '',
+                selected: @name.selected_status_id},
                title: 'Select status',
                tabindex: increment_tab_index,
                autocomplete: "off",
-               class:"form-control",
+               class: "form-control",
                disabled: false,
                required: true) %>
   </div>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 14-July-2026
+  :jira_id: '5197'
+  :description: |-
+    Set the status field to n/a when converting a scientific name to phrase name
 - :date: 13-July-2026
   :jira_id: '5845'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.38
+appversion=5.1.4.39

--- a/test/controllers/names/edit/convert_scientific_to_phrase_name_test.rb
+++ b/test/controllers/names/edit/convert_scientific_to_phrase_name_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single controller test.
+#
+# Editing a scientific name "as" a phrase name offers only the [n/a] status,
+# so the status select must default to it. The name's stored status
+# (legitimate) is not among a phrase name's options, so without a default the
+# select renders blank.
+class ConvertScientificToPhraseNameTest < ActionController::TestCase
+  tests NamesController
+  setup do
+    @name = names(:a_species)
+    @request.headers["Accept"] = "application/javascript"
+  end
+
+  def get_edit_as(new_category)
+    get(:edit_as_category,
+        params: { id: @name.id,
+                  tab: "edit_name",
+                  new_category: new_category },
+        session: { username: "fred",
+                   user_full_name: "Fred Jones",
+                   groups: ["edit"] })
+  end
+
+  test "the name under test is a scientific name with a legitimate status" do
+    assert_equal "scientific", @name.name_category.name
+    assert_equal "legitimate", @name.name_status.name
+  end
+
+  test "editing a scientific name as a phrase name renders the edit tab" do
+    get_edit_as(NameCategory::PHRASE_NAME)
+    assert_response :success, "Cannot edit a scientific name as a phrase name"
+    assert_select "select#name_name_status_id", true,
+                  "Should show the name status select."
+  end
+
+  test "editing a scientific name as a phrase name offers only the [n/a] status" do
+    get_edit_as(NameCategory::PHRASE_NAME)
+    assert_select "select#name_name_status_id" do
+      assert_select "option[value=?]", name_statuses(:na).id.to_s,
+                    { count: 1 },
+                    "Should offer the [n/a] status."
+      assert_select "option[value=?]", name_statuses(:legitimate).id.to_s,
+                    { count: 0 },
+                    "Should not offer a scientific-only status."
+    end
+  end
+
+  test "editing a scientific name as a phrase name defaults the status to [n/a]" do
+    get_edit_as(NameCategory::PHRASE_NAME)
+    assert_select "select#name_name_status_id" do
+      assert_select "option[selected][value=?]", name_statuses(:na).id.to_s,
+                    { count: 1 },
+                    "Status should default to [n/a] for a phrase name."
+    end
+  end
+
+  test "editing a scientific name as a scientific name keeps its own status" do
+    get_edit_as(NameCategory::SCIENTIFIC_CATEGORY)
+    assert_response :success
+    assert_select "select#name_name_status_id" do
+      assert_select "option[selected][value=?]",
+                    name_statuses(:legitimate).id.to_s,
+                    { count: 1 },
+                    "Status should stay on the name's own status."
+    end
+  end
+end


### PR DESCRIPTION
## Description
- set default name status to n/a (the only status available) when converting a scientific name to phrase name 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
