### PR TITLE
NSL-5692: Loader: misapplications without preferred matches now respect their parent's use-existing-instance choice

### DIFF
--- a/app/models/loader/name/make_one_instance.rb
+++ b/app/models/loader/name/make_one_instance.rb
@@ -83,6 +83,25 @@ class Loader::Name::MakeOneInstance
     {declines: 1, declines_reasons: {no_preferred_match: 1}}
   end
 
+  def parent_using_existing
+    log_to_table(declined_entry("parent is using existing instance"))
+    {declines: 1, declines_reasons: {parent_is_using_existing_instance: 1}}
+  end
+
+  def no_parent
+    log_to_table(declined_entry("no parent"))
+    {declines: 1, declines_reasons: {no_parent: 1}}
+  end
+
+  def parent_no_preferred_match
+    log_to_table(declined_entry("parent no preferred match"))
+    {declines: 1, declines_reasons: {parent_no_preferred_match: 1}}
+  end
+
+  def declined_entry(message)
+    "#{Constants::DECLINED_INSTANCE}: #{message} for #{@loader_name.simple_name} ##{@loader_name.id}"
+  end
+
   def heading
     log_to_table("#{Constants::DECLINED_INSTANCE} - heading entries not processed ##{@loader_name.id} #{@loader_name.simple_name}")
     {declines: 1, declines_reasons: {heading_so_not_processed: 1}}
@@ -105,6 +124,11 @@ class Loader::Name::MakeOneInstance
   end
 
   def create_misapp
+    return no_parent if @loader_name.parent.blank?
+    return parent_no_preferred_match if @loader_name.parent.preferred_match.blank?
+    return parent_using_existing if @loader_name.parent
+                                                .preferred_match
+                                                .use_existing_instance == true
     return no_preferred_match unless @loader_name.preferred_matches.size > 0
 
     result_h = {creates: 0, declines: 0, errors: 0}

--- a/app/models/loader/name/make_one_instance/make_one_misapp_instance.rb
+++ b/app/models/loader/name/make_one_instance/make_one_misapp_instance.rb
@@ -11,13 +11,8 @@ class Loader::Name::MakeOneInstance::MakeOneMisappInstance
   end
 
   def create
-    return parent_using_existing if @loader_name.parent
-                                                .preferred_match
-                                                .use_existing_instance == true
     return already_noted if @match.relationship_instance_id.present?
     return misapp_already_attached if misapp_already_attached?
-    return parent_no_preferred_match if @loader_name.parent
-                     .preferred_match.blank?
     return parent_no_standalone if @loader_name.parent.preferred_match.try("standalone_instance_id").blank?
     return no_misapplied_type if @loader_name.synonym_type.blank?
     return no_relationship_instance_type if @match
@@ -67,16 +62,6 @@ class Loader::Name::MakeOneInstance::MakeOneMisappInstance
     record_misapp_already_there
     log_to_table(declined_entry("misapplied instance already there"))
     {declines: 1, declines_reasons: {misapplied_instance_already_there: 1}}
-  end
-
-  def parent_using_existing
-    log_to_table(declined_entry("parent is using existing instance"))
-    {declines: 1, declines_reasons: {parent_is_using_existing_instance: 1}}
-  end
-
-  def parent_no_preferred_match
-    log_to_table(declined_entry("parent has no preferred match"))
-    {declines: 1, declines_reasons: {parent_has_no_preferred_match: 1}}
   end
 
   def declined_entry(message)

--- a/app/models/loader/name/make_one_instance/make_one_synonymy_instance.rb
+++ b/app/models/loader/name/make_one_instance/make_one_synonymy_instance.rb
@@ -24,10 +24,10 @@ class Loader::Name::MakeOneInstance::MakeOneSynonymyInstance
       return {declines: 1, declines_reasons: {synonym_has_no_parent: 1}}
     end
     if @loader_name.parent.preferred_match.blank?
-      entry = "#{Constants::DECLINED_INSTANCE} -: parent has no preferred match"
+      entry = "#{Constants::DECLINED_INSTANCE} -: parent no preferred match"
       entry += " #{@loader_name.simple_name} ##{@loader_name.id}"
       log_to_table(entry)
-      return {declines: 1, declines_reasons: {parent_has_no_preferred_match: 1}}
+      return {declines: 1, declines_reasons: {parent_no_preferred_match: 1}}
     end
     if @loader_name.parent.preferred_match.use_existing_instance == true
       entry = "#{Constants::DECLINED_INSTANCE} -: parent is using existing instance for "

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,11 @@
+- :date: 15-July-2026
+  :jira_id: '5692'
+  :description: |-
+    Loader: misapplications without preferred matches now respect their parent's "use existing instance" choice 
+- :date: 14-July-2026
+  :jira_id: '5197'
+  :description: |-
+    Set the status field to n/a when converting a scientific name to phrase name
 - :date: 14-July-2026
   :jira_id: '5197'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.39
+appversion=5.1.4.40

--- a/test/controllers/search/loader/names/any_batch_test.rb
+++ b/test/controllers/search/loader/names/any_batch_test.rb
@@ -30,7 +30,7 @@ class SearchLoaderNameAnyBatchTest < ActionController::TestCase
                    groups: [:login, :"batch-loader"] })
     assert_response :success
     assert_select "#search-results-summary",
-                  /\b[1-9] records*\b/,
+                  /\b[1-9]\d* records*\b/,
                   "Should find at least one loader name record with any-batch wildcard search"
   end
 end

--- a/test/fixtures/loader_name_matches.yml
+++ b/test/fixtures/loader_name_matches.yml
@@ -1,0 +1,65 @@
+_fixture:
+  model_class: Loader::Name::Match
+
+# Supports test/models/loader/name/make_one_instance/create_misapp_test.rb
+# and test/models/loader/name/make_one_instance/make_one_synonymy_instance_test.rb
+#
+# name/instance associations are arbitrary and reused across rows below -
+# only the loader_name association and the use_existing_instance /
+# standalone_instance_* / relationship_instance_id flags matter for those
+# tests.
+
+# zzz_test_parent_using_existing's preferred match: uses an existing
+# instance, so nothing further should be created off it.
+match_zzz_test_parent_using_existing:
+  loader_name: zzz_test_parent_using_existing
+  name: metrosideros_costata
+  instance: gaertner_created_metrosideros_costata
+  use_existing_instance: true
+  instance_choice_confirmed: true
+  standalone_instance_found: true
+  standalone_instance: gaertner_created_metrosideros_costata
+  created_by: tester
+  updated_by: tester
+
+# zzz_test_parent_with_match's preferred match: an ordinary match, not
+# using an existing instance, so processing should be able to proceed
+# past the parent guards.
+match_zzz_test_parent_with_match:
+  loader_name: zzz_test_parent_with_match
+  name: metrosideros_costata
+  instance: gaertner_created_metrosideros_costata
+  created_by: tester
+  updated_by: tester
+
+# Each synonym test loader_name needs its own preferred match, because
+# MakeOneSynonymyInstance#create dereferences @match (loader_name's own
+# preferred_match) as its very first check, before any of the parent
+# guards under test here.
+match_synonym_no_parent:
+  loader_name: synonym_no_parent
+  name: metrosideros_costata
+  instance: gaertner_created_metrosideros_costata
+  created_by: tester
+  updated_by: tester
+
+match_synonym_parent_no_pref_match:
+  loader_name: synonym_parent_no_pref_match
+  name: metrosideros_costata
+  instance: gaertner_created_metrosideros_costata
+  created_by: tester
+  updated_by: tester
+
+match_synonym_parent_using_existing:
+  loader_name: synonym_parent_using_existing
+  name: metrosideros_costata
+  instance: gaertner_created_metrosideros_costata
+  created_by: tester
+  updated_by: tester
+
+match_synonym_guards_pass:
+  loader_name: synonym_guards_pass
+  name: metrosideros_costata
+  instance: gaertner_created_metrosideros_costata
+  created_by: tester
+  updated_by: tester

--- a/test/fixtures/loader_names.yml
+++ b/test/fixtures/loader_names.yml
@@ -56,3 +56,188 @@ accepted_three:
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
 
+# --- Fixtures for Loader::Name::MakeOneInstance guard-ordering tests ---
+# (test/models/loader/name/make_one_instance/)
+#
+# create_misapp and MakeOneSynonymyInstance#create must check, in this
+# order, before ever dereferencing further: does the loader_name have a
+# parent? does that parent have a preferred match? only then is it safe
+# to check whether that match uses an existing instance.
+#
+# These use dedicated parent fixtures with deliberately nonsense names
+# (NOT accepted_one/two/three). Search::Loader::Name::FieldRule's
+# "simple-name:" rule matches a record if ITS OWN name matches, OR its
+# PARENT's name matches, OR one of its CHILDREN's/SIBLINGS' names match -
+# so a child of accepted_one ("Hardenbergia violacea") would itself start
+# matching "Hardenbergia violacea" searches. Giving parents unique,
+# unsearched-for names avoids that collision entirely.
+#
+# New rows here also show up in *unscoped* count assertions elsewhere
+# (tests searching "* any-batch:" / "* batch-name: *" /
+# "no-hybrid-flag: any-batch:" across every loader name in every batch).
+# See the count updates in:
+#   test/models/search/loader/name/simple_with_any_batch_test.rb
+#   test/models/search/loader/name/print/simple_with_any_batch_test.rb
+#   test/models/search/loader/name/simple_with_batch_name_asterisk_test.rb
+#   test/models/search/loader/name/hybrid/no_hybrid_flag_test.rb
+
+zzz_test_parent_no_match:
+  seq: 0
+  record_type: accepted
+  loader_batch: batch_one
+  simple_name: Zzz test parent no match
+  simple_name_as_loaded: Zzz test parent no match
+  full_name: Zzz test parent no match
+  family: Myrtaceae
+  rank: species
+  created_by: tester
+  updated_by: tester
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+zzz_test_parent_with_match:
+  seq: 0
+  record_type: accepted
+  loader_batch: batch_one
+  simple_name: Zzz test parent with match
+  simple_name_as_loaded: Zzz test parent with match
+  full_name: Zzz test parent with match
+  family: Myrtaceae
+  rank: species
+  created_by: tester
+  updated_by: tester
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+zzz_test_parent_using_existing:
+  seq: 0
+  record_type: accepted
+  loader_batch: batch_one
+  simple_name: Zzz test parent using existing
+  simple_name_as_loaded: Zzz test parent using existing
+  full_name: Zzz test parent using existing
+  family: Myrtaceae
+  rank: species
+  created_by: tester
+  updated_by: tester
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+misapp_no_parent:
+  seq: 0
+  record_type: misapplied
+  loader_batch: batch_one
+  simple_name: Misapp with no parent
+  simple_name_as_loaded: Misapp with no parent
+  full_name: Misapp with no parent
+  family: Myrtaceae
+  rank: species
+  created_by: tester
+  updated_by: tester
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+misapp_parent_no_pref_match:
+  seq: 0
+  record_type: misapplied
+  loader_batch: batch_one
+  parent: zzz_test_parent_no_match
+  simple_name: Misapp whose parent has no preferred match
+  simple_name_as_loaded: Misapp whose parent has no preferred match
+  full_name: Misapp whose parent has no preferred match
+  family: Myrtaceae
+  rank: species
+  created_by: tester
+  updated_by: tester
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+misapp_parent_using_existing:
+  seq: 0
+  record_type: misapplied
+  loader_batch: batch_one
+  parent: zzz_test_parent_using_existing
+  simple_name: Misapp whose parent uses an existing instance
+  simple_name_as_loaded: Misapp whose parent uses an existing instance
+  full_name: Misapp whose parent uses an existing instance
+  family: Myrtaceae
+  rank: species
+  created_by: tester
+  updated_by: tester
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+misapp_guards_pass:
+  seq: 0
+  record_type: misapplied
+  loader_batch: batch_one
+  parent: zzz_test_parent_with_match
+  simple_name: Misapp that passes all parent guards
+  simple_name_as_loaded: Misapp that passes all parent guards
+  full_name: Misapp that passes all parent guards
+  family: Myrtaceae
+  rank: species
+  created_by: tester
+  updated_by: tester
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+synonym_no_parent:
+  seq: 0
+  record_type: synonym
+  loader_batch: batch_one
+  simple_name: Synonym with no parent
+  simple_name_as_loaded: Synonym with no parent
+  full_name: Synonym with no parent
+  family: Myrtaceae
+  rank: species
+  created_by: tester
+  updated_by: tester
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+synonym_parent_no_pref_match:
+  seq: 0
+  record_type: synonym
+  loader_batch: batch_one
+  parent: zzz_test_parent_no_match
+  simple_name: Synonym whose parent has no preferred match
+  simple_name_as_loaded: Synonym whose parent has no preferred match
+  full_name: Synonym whose parent has no preferred match
+  family: Myrtaceae
+  rank: species
+  created_by: tester
+  updated_by: tester
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+synonym_parent_using_existing:
+  seq: 0
+  record_type: synonym
+  loader_batch: batch_one
+  parent: zzz_test_parent_using_existing
+  simple_name: Synonym whose parent uses an existing instance
+  simple_name_as_loaded: Synonym whose parent uses an existing instance
+  full_name: Synonym whose parent uses an existing instance
+  family: Myrtaceae
+  rank: species
+  created_by: tester
+  updated_by: tester
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+synonym_guards_pass:
+  seq: 0
+  record_type: synonym
+  loader_batch: batch_one
+  parent: zzz_test_parent_with_match
+  simple_name: Synonym that passes all parent guards
+  simple_name_as_loaded: Synonym that passes all parent guards
+  full_name: Synonym that passes all parent guards
+  family: Myrtaceae
+  rank: species
+  created_by: tester
+  updated_by: tester
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+

--- a/test/models/loader/name/make_one_instance/create_misapp_test.rb
+++ b/test/models/loader/name/make_one_instance/create_misapp_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Loader::Name::MakeOneInstance#create_misapp must check, in this exact
+# order, before it is ever safe to look at whether the parent's preferred
+# match uses an existing instance:
+#   1. does the loader_name have a parent at all?
+#   2. does that parent have a preferred match?
+#   3. only then: does that match use an existing instance?
+# Getting this order wrong raises a NoMethodError on nil instead of
+# returning a clean decline, because Loader::Name#preferred_match returns
+# nil when there is no preferred match, and belongs_to :parent is optional.
+class LoaderNameMakeOneInstanceCreateMisappTest < ActiveSupport::TestCase
+  JOB_NUMBER = 999_999
+
+  def creator_for(loader_name_key)
+    Loader::Name::MakeOneInstance.new(loader_names(loader_name_key),
+                                       "tester",
+                                       JOB_NUMBER)
+  end
+
+  test "declines with no_parent when the misapp has no parent" do
+    result = creator_for(:misapp_no_parent).create_misapp
+    assert_equal({declines: 1, declines_reasons: {no_parent: 1}}, result)
+  end
+
+  test "declines with parent_no_preferred_match when the parent has " \
+       "no preferred match" do
+    result = creator_for(:misapp_parent_no_pref_match).create_misapp
+    assert_equal({declines: 1,
+                  declines_reasons: {parent_no_preferred_match: 1}},
+                 result)
+  end
+
+  test "declines with parent_is_using_existing_instance when the " \
+       "parent's preferred match uses an existing instance" do
+    result = creator_for(:misapp_parent_using_existing).create_misapp
+    assert_equal({declines: 1,
+                  declines_reasons: {parent_is_using_existing_instance: 1}},
+                 result)
+  end
+
+  test "does not raise once all parent guards pass, and falls through " \
+       "to the next check" do
+    result = creator_for(:misapp_guards_pass).create_misapp
+    assert_equal({declines: 1, declines_reasons: {no_preferred_match: 1}},
+                 result)
+  end
+end

--- a/test/models/loader/name/make_one_instance/make_one_synonymy_instance_test.rb
+++ b/test/models/loader/name/make_one_instance/make_one_synonymy_instance_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Loader::Name::MakeOneInstance::MakeOneSynonymyInstance#create must check,
+# in this exact order, before it is ever safe to look at whether the
+# parent's preferred match uses an existing instance:
+#   1. does the relationship instance already exist for the synonym's own
+#      match? (pre-existing check, unaffected by this)
+#   2. does the loader_name have a parent at all?
+#   3. does that parent have a preferred match?
+#   4. only then: does that match use an existing instance?
+# Getting 2-4 out of order raises a NoMethodError on nil instead of
+# returning a clean decline, because Loader::Name#preferred_match returns
+# nil when there is no preferred match, and belongs_to :parent is optional.
+class LoaderNameMakeOneInstanceMakeOneSynonymyInstanceTest < ActiveSupport::TestCase
+  JOB_NUMBER = 999_999
+
+  def creator_for(loader_name_key)
+    Loader::Name::MakeOneInstance::MakeOneSynonymyInstance.new(
+      loader_names(loader_name_key), "tester", JOB_NUMBER
+    )
+  end
+
+  test "declines with synonym_has_no_parent when the synonym has no parent" do
+    result = creator_for(:synonym_no_parent).create
+    assert_equal({declines: 1, declines_reasons: {synonym_has_no_parent: 1}},
+                 result)
+  end
+
+  test "declines with parent_no_preferred_match when the parent has " \
+       "no preferred match" do
+    result = creator_for(:synonym_parent_no_pref_match).create
+    assert_equal({declines: 1,
+                  declines_reasons: {parent_no_preferred_match: 1}},
+                 result)
+  end
+
+  test "declines with parent_is_using_existing_instance when the " \
+       "parent's preferred match uses an existing instance" do
+    result = creator_for(:synonym_parent_using_existing).create
+    assert_equal({declines: 1,
+                  declines_reasons: {parent_is_using_existing_instance: 1}},
+                 result)
+  end
+
+  test "does not raise once all parent guards pass, and falls through " \
+       "to the next check" do
+    result = creator_for(:synonym_guards_pass).create
+    assert_equal({declines: 1,
+                  declines_reasons: {parent_has_no_standalone_instance: 1}},
+                 result)
+  end
+end

--- a/test/models/search/loader/name/hybrid/no_hybrid_flag_test.rb
+++ b/test/models/search/loader/name/hybrid/no_hybrid_flag_test.rb
@@ -32,8 +32,10 @@ class SearchLoaderNameNoHybridFlagTest < ActiveSupport::TestCase
     search = Search::Base.new(params)
     assert search.executed_query.results.is_a?(ActiveRecord::Relation),
            "Results should be an ActiveRecord::Relation."
-    assert_equal 3,
+    assert_equal 14,
                  search.executed_query.results.size,
-                 "Exactly 3 results expected."
+                 "Exactly 14 results expected (3 original fixtures + 11 " \
+                 "from Loader::Name::MakeOneInstance guard-ordering " \
+                 "tests, none of which set hybrid_flag)."
   end
 end

--- a/test/models/search/loader/name/print/simple_with_any_batch_test.rb
+++ b/test/models/search/loader/name/print/simple_with_any_batch_test.rb
@@ -33,8 +33,13 @@ class SearchLoaderNameAndPrintSimpleWithAnyBatchTest < ActiveSupport::TestCase
     search = Search::Base.new(params)
     assert search.executed_query.results.is_a?(Array),
       "Results should be an Array."
-    assert_equal 9,
+    assert_equal 20,
                  search.executed_query.results.size,
-                 "Exactly 9 results expected."
+                 "Exactly 20 results expected (9 original + 11 from " \
+                 "Loader::Name::MakeOneInstance guard-ordering tests - " \
+                 "none of the 11 set comment/distribution, so " \
+                 "RewriteResultsShowingExtras adds exactly 1 entry per " \
+                 "record with no expansion, even for the 3 that are " \
+                 "record_type accepted)."
   end
 end

--- a/test/models/search/loader/name/simple_with_any_batch_test.rb
+++ b/test/models/search/loader/name/simple_with_any_batch_test.rb
@@ -32,8 +32,9 @@ class SearchLoaderNameSimpleWithAnyBatchTest < ActiveSupport::TestCase
     search = Search::Base.new(params)
     assert search.executed_query.results.is_a?(ActiveRecord::Relation),
            "Results should be an ActiveRecord::Relation."
-    assert_equal 3,
+    assert_equal 14,
                  search.executed_query.results.size,
-                 "Exactly 3 results expected."
+                 "Exactly 14 results expected (3 original fixtures + 11 " \
+                 "from Loader::Name::MakeOneInstance guard-ordering tests)."
   end
 end

--- a/test/models/search/loader/name/simple_with_batch_name_asterisk_test.rb
+++ b/test/models/search/loader/name/simple_with_batch_name_asterisk_test.rb
@@ -35,8 +35,9 @@ class SearchLoaderNameSimpleWithBatchNameAsteriskTest < ActiveSupport::TestCase
     search = Search::Base.new(params)
     assert search.executed_query.results.is_a?(ActiveRecord::Relation),
            "Results should be an ActiveRecord::Relation."
-    assert_equal 3,
+    assert_equal 14,
                  search.executed_query.results.size,
-                 "Exactly 3 results expected."
+                 "Exactly 14 results expected (3 original fixtures + 11 " \
+                 "from Loader::Name::MakeOneInstance guard-ordering tests)."
   end
 end


### PR DESCRIPTION
## Description
Loader batch processing change - fairly deep in the internals.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
See Jira

## Tests
- [x] Unit tests - from Claude
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
