### PR TITLE
NSL-3748: Name name_path: Stop adding leading slash to common name and other name_paths on Copy and Refresh name path

### DIFF
--- a/app/models/concerns/name_name_pathable.rb
+++ b/app/models/concerns/name_name_pathable.rb
@@ -7,7 +7,9 @@ module NameNamePathable
   def make_name_path
     path = ""
     path = parent.name_path if parent
-    path += "/#{name_element&.strip}"
+    path += "/" unless path.blank?
+    path += name_element.strip unless name_element.blank?
+    path
   end
 
   def build_name_path

--- a/app/models/concerns/name_validatable.rb
+++ b/app/models/concerns/name_validatable.rb
@@ -55,6 +55,7 @@ module NameValidatable
     validate :genus_parent_must_match_family_if_both_ranked_family
     validates :name_path, presence: true
     validate :name_type_autonym_for_restricted_ranks_only
+    validate :name_path_no_slash_unless_parent
   end
 
   def name_element_is_stripped
@@ -78,6 +79,14 @@ module NameValidatable
     return if name_rank.compatible_with_autonym?
 
     errors.add(:name_type_id, "autonym must either be infrageneric or infraspecific rank")
+  end
+
+  def name_path_no_slash_unless_parent
+    return unless parent.blank?
+    return if name_path.blank?
+    return unless name_path.match(/\A\//)
+
+    errors.add(:name_path, "should have no leading slash because no parent")
   end
 
   def genus_parent_must_match_family_if_both_ranked_family

--- a/app/models/name/as_edited.rb
+++ b/app/models/name/as_edited.rb
@@ -119,7 +119,7 @@ class Name::AsEdited < Name::AsTypeahead
     name = Name::AsEdited.new(params)
     name.resolve_typeahead_params(typeahead_params)
     create_hybrid_name_element(name)
-    create_name_path(name)
+    name.build_name_path
     raise name.errors.full_messages.first.to_s unless name.save_with_username(username)
 
     name.set_names!
@@ -138,14 +138,6 @@ class Name::AsEdited < Name::AsTypeahead
     return unless name_category.scientific_hybrid_formula?
 
     self.name_element = "#{parent.name_element} #{name_type.connector} #{second_parent.name_element}"
-  end
-
-  def self.create_name_path(name)
-    path = ""
-    path = name.parent.name_path if name.parent
-    path += "/" unless path.blank?
-    path += name.name_element.strip if name.name_element
-    name.name_path = path
   end
 
   def update_if_changed(params, typeahead_params, username)

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 16-July-2026
+  :jira_id: '3748'
+  :description: |-
+    Name name_path: Stop adding leading slash to common name and other name_paths on Copy and Refresh name path
 - :date: 15-July-2026
   :jira_id: '5692'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.40
+appversion=5.1.4.41

--- a/test/models/concerns/name_name_pathable_test.rb
+++ b/test/models/concerns/name_name_pathable_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# NameNamePathable#make_name_path / #build_name_path build a name's
+# slash-separated ancestry path from its parent's name_path plus its own
+# name_element, with no leading slash when there is no parent.
+class NameNamePathableTest < ActiveSupport::TestCase
+  test "a root name (no parent) has a path with no leading slash" do
+    name = names(:the_regnum)
+    assert_nil name.parent, "fixture should have no parent"
+    assert_equal "Plantae", name.make_name_path
+  end
+
+  test "a name with a parent joins the parent's name_path and its own name_element with a slash" do
+    name = names(:a_division)
+    assert_equal names(:the_regnum), name.parent, "fixture should have the_regnum as parent"
+    assert_equal "Plantae/Magnoliophyta", name.make_name_path
+  end
+
+  test "whitespace around name_element is stripped when building the path" do
+    name = Name.new(name_element: "  Hibiscus  ", parent: names(:the_regnum))
+    assert_equal "Plantae/Hibiscus", name.make_name_path
+  end
+
+  test "a blank parent name_path does not add a leading slash" do
+    name = Name.new(name_element: "Hibiscus", parent: Name.new(name_path: ""))
+    assert_equal "Hibiscus", name.make_name_path
+  end
+
+  test "no parent and no name_element returns an empty string" do
+    name = Name.new
+    assert_equal "", name.make_name_path
+  end
+
+  test "build_name_path sets name_path to the result of make_name_path" do
+    name = Name.new(name_element: "Malvaceae")
+    name.build_name_path
+    assert_equal "Malvaceae", name.name_path
+  end
+end

--- a/test/models/concerns/name_validatable_test.rb
+++ b/test/models/concerns/name_validatable_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# NameValidatable#name_path_no_slash_unless_parent rejects a leading slash
+# on name_path when the name has no parent (a root name's path should just
+# be its own name_element), but allows a leading slash when there is a
+# parent.
+class NameValidatableTest < ActiveSupport::TestCase
+  test "a root name's name_path may not have a leading slash" do
+    name = names(:the_regnum)
+    assert_nil name.parent, "fixture should have no parent"
+    assert name.valid?, "Name should be valid. Errs: #{name.errors.full_messages.join('; ')}"
+
+    name.name_path = "/Plantae"
+
+    assert_not name.valid?
+    assert_includes name.errors[:name_path], "should have no leading slash because no parent"
+  end
+
+  test "a root name's name_path with no leading slash is valid" do
+    name = names(:the_regnum)
+    name.name_path = "Plantae"
+
+    assert name.valid?, "Name should be valid. Errs: #{name.errors.full_messages.join('; ')}"
+  end
+
+  test "a blank name_path on a root name does not raise, though it is invalid for a different reason" do
+    name = names(:the_regnum)
+    name.name_path = ""
+
+    assert_not name.valid?
+    refute_includes name.errors[:name_path], "should have no leading slash because no parent"
+    assert_includes name.errors[:name_path], "can't be blank"
+  end
+
+  test "a nil name_path on a root name does not raise" do
+    name = names(:the_regnum)
+    name.name_path = nil
+
+    assert_nothing_raised { name.valid? }
+  end
+
+  test "a name with a parent may have a leading slash in name_path" do
+    name = names(:a_division)
+    assert name.parent.present?, "fixture should have a parent"
+    name.name_path = "/Plantae/Magnoliophyta"
+
+    assert name.valid?, "Name should be valid. Errs: #{name.errors.full_messages.join('; ')}"
+  end
+end


### PR DESCRIPTION
## Description
Claude summary:

 Consolidates duplicate name_path-building logic. 

Previously `NameNamePathable#make_name_path` used `path += "/#{name_element&.strip}" `unconditionally (always prepending a slash, even for root-level names with no parent), while `Name::AsEdited.create_name_path` had a separate, slightly different implementation that correctly omitted the leading slash when theres no parent. 

This change makes the concerns `make_name_path` match the correct logic, deletes the now-redundant `create_name_path` in `as_edited.rb`, and switches its one caller to `name.build_name_path`. 

It also adds a validation (`name_path_no_slash_unless_parent`) to guard against a root-level name ever getting a leading slash again.

Correctness: Logic checks out — `path += "/" unless path.blank?` then appends the stripped `name_element` only if present, so root names get no leading slash while child names get `parent_path/element`. This fixes a real bug (spurious leading / on top-level names) and is now covered by a validation rather than just convention.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## How to Test
See Jira

## Tests
- [x] Unit tests - by Claude
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
