### PR TITLE
NSL-3228: Name Delete: Check after Services call that Name really has been deleted

### DIFF
--- a/app/controllers/names_deletes_controller.rb
+++ b/app/controllers/names_deletes_controller.rb
@@ -24,6 +24,7 @@ class NamesDeletesController < ApplicationController
     raise "Not confirmed" unless @names_delete.save! # i.e. confirmed
 
     delete_via_service(names_delete_params)
+    raise "Name not deleted" unless name_is_gone?
     render partial: "ok"
   rescue StandardError => e
     logger.error("Exception deleting name: #{e}")
@@ -39,6 +40,12 @@ class NamesDeletesController < ApplicationController
     raise "Not saved" unless @name.delete_with_reason(
       @names_delete.assembled_reason
     )
+  end
+
+  # Services response on failure may not reliably give a clue that the delete
+  # failed, so we have to check.
+  def name_is_gone?
+    !Name.exists?(names_delete_params[:name_id])
   end
 
   def assemble_error_message(err)

--- a/app/models/name/as_services.rb
+++ b/app/models/name/as_services.rb
@@ -144,6 +144,10 @@ class Name::AsServices < Name
   # "There are 1 that cite this.", raw database messages like multi-level
   # foreign key technical errors, but we get them often enough that we
   # need to pass them through to the application GUI.
+  #
+  # In 2026 I'm finding that Editor is thinking Name is deleted when an error
+  # has occurred in Services - the return code is still 200 from Services and 
+  # the json says "ok"
   def delete_with_reason(reason)
     url = Name::AsServices.delete_url(id, reason)
     s_response = RestClient.delete(url, accept: :json)

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,6 +1,10 @@
 - :date: 17-July-2026
   :jira_id: '3228'
   :description: |-
+    Name Delete: Check after Services call that Name really has been deleted
+- :date: 17-July-2026
+  :jira_id: '3228'
+  :description: |-
     Name Delete: Cap extra information input at 199 characters so it should never be rejected
 - :date: 17-July-2026
   :jira_id: '5861'

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.44
+appversion=5.1.4.45

--- a/test/controllers/names_deletes/confirm/for_editor/renders_error_when_service_lies_about_success_test.rb
+++ b/test/controllers/names_deletes/confirm/for_editor/renders_error_when_service_lies_about_success_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single controller test.
+#
+# Regression test: the external Name Services delete API can respond with
+# HTTP 200 and {"ok": true} even when it did not actually delete the name
+# (see the comment on Name::AsServices#delete_with_reason). Unlike the
+# genuine-success case, this stub's response block does NOT delete the
+# fixture row, simulating the service lying about success.
+# NamesDeletesController#name_is_gone? must catch this and report an error
+# rather than telling the user the name was deleted.
+class NamesDeleteConfirmForEditorRendersErrorWhenServiceLiesAboutSuccessTest < ActionController::TestCase
+  tests NamesDeletesController
+
+  setup do
+    @name = names(:name_to_delete)
+    @reason = "some reason"
+    @extra_info = ""
+    stub_it
+  end
+
+  def a
+    "http://localhost:9090/nsl/services/rest/name/apni/#{@name.id}/api/delete"
+  end
+
+  def b
+    "?apiKey=test-api-key&reason=#{@reason}"
+  end
+
+  def stub_it
+    stub_request(:delete, "#{a}#{b}")
+      .with(headers: { "Accept" => "application/json",
+                       "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+                       "Host" => "localhost:9090"})
+      .to_return(status: 200, body: '{"ok": true}', headers: { "Content-Type" => "application/json" })
+  end
+
+  test "renders an error and does not claim success when the service says ok but the name is still there" do
+    @request.headers["Accept"] = "application/javascript"
+    delete(:confirm,
+           params: { names_delete: { name_id: @name.id,
+                                     reason: @reason,
+                                     extra_info: @extra_info } },
+           session: { username: "fred",
+                      user_full_name: "Fred Jones",
+                      groups: ["edit"] })
+    assert_response :success
+    assert_includes @response.body, "Name not deleted"
+    assert_not_includes @response.body, "Record deleted"
+    assert Name.exists?(@name.id), "Name should still exist - the service did not really delete it"
+  end
+end

--- a/test/controllers/names_deletes/confirm/for_editor/renders_ok_when_name_is_actually_gone_test.rb
+++ b/test/controllers/names_deletes/confirm/for_editor/renders_ok_when_name_is_actually_gone_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single controller test.
+#
+# The stub's response block deletes the fixture row itself, simulating the
+# external Name Services app deleting the same underlying row before it
+# responds. This is the genuine-success case: the service says ok, and the
+# name really is gone.
+class NamesDeleteConfirmForEditorRendersOkWhenNameIsActuallyGoneTest < ActionController::TestCase
+  tests NamesDeletesController
+
+  setup do
+    @name = names(:name_to_delete)
+    @reason = "some reason"
+    @extra_info = ""
+    stub_it
+  end
+
+  def a
+    "http://localhost:9090/nsl/services/rest/name/apni/#{@name.id}/api/delete"
+  end
+
+  def b
+    "?apiKey=test-api-key&reason=#{@reason}"
+  end
+
+  def stub_it
+    name_id = @name.id
+    stub_request(:delete, "#{a}#{b}")
+      .with(headers: { "Accept" => "application/json",
+                       "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+                       "Host" => "localhost:9090"})
+      .to_return do |_request|
+        Name.delete(name_id)
+        { status: 200, body: '{"ok": true}', headers: { "Content-Type" => "application/json" } }
+      end
+  end
+
+  test "renders ok and the name is gone when the service really deletes it" do
+    @request.headers["Accept"] = "application/javascript"
+    delete(:confirm,
+           params: { names_delete: { name_id: @name.id,
+                                     reason: @reason,
+                                     extra_info: @extra_info } },
+           session: { username: "fred",
+                      user_full_name: "Fred Jones",
+                      groups: ["edit"] })
+    assert_response :success
+    assert_includes @response.body, "Record deleted"
+    assert_not Name.exists?(@name.id)
+  end
+end


### PR DESCRIPTION
## Description
See JIra

## Type of change
- [x] Bug fix 

## How to Test
See Jira - hard to test - users should make sure they can delete Names, that's about all.

## Tests
- [x] Unit tests - Claude
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
