### PR TITLE
NSL-5864: Search: Fix unhandled errors that crash Search page

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -17,7 +17,7 @@ class SearchController < ApplicationController
     params[:error_message] = "That query did not work. Please check the \
     search directives and arguments."
     logger.error("Search error: #{e}")
-    @search = Search::Error.new(params) unless @search.present?
+    run_empty_search_to_show_error(params)
   rescue StandardError => e
     params[:error_message] = e.to_s
     run_empty_search_to_show_error(params)

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 21-July-2026
+  :jira_id: '5864'
+  :description: |-
+    Search: Fix unhandled errors that crash Search page
+- :date: 21-July-2026
   :jira_id: '5855'
   :description: |-
     Service object for soft delete of names

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.50
+appversion=5.1.4.51

--- a/test/controllers/search/errors/statement_invalid_test.rb
+++ b/test/controllers/search/errors/statement_invalid_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Regression test: SearchController#search used to rescue
+# ActiveRecord::StatementInvalid by building a Search::Error, a class that
+# does not exist anywhere in the codebase. That meant a malformed-query SQL
+# error would crash the rescue handler itself (NameError: uninitialized
+# constant Search::Error) instead of showing the friendly
+# "That query did not work" message. The fix routes this rescue through the
+# same run_empty_search_to_show_error helper already used - and already
+# proven safe - by the generic StandardError rescue below it.
+class SearchControllerStatementInvalidTest < ActionController::TestCase
+  tests SearchController
+
+  test "a StatementInvalid error during search renders the search page instead of crashing" do
+    SearchController.stub_any_instance(
+      :run_local_search,
+      -> { raise ActiveRecord::StatementInvalid, "malformed SQL" }
+    ) do
+      get(:search,
+          params: { query_target: "Names", query_string: "angophora" },
+          session: { username: "fred",
+                     user_full_name: "Fred Jones",
+                     groups: [] })
+    end
+
+    assert_response :success
+    assert_match(/That query did not work/, response.body)
+  end
+end


### PR DESCRIPTION
## Description
Claude says:

Reviewed — this is a good fix, not just a mechanical change. It closes out a bug that's been live since at least February 2022.

What's happening: The rescue ActiveRecord::StatementInvalid branch called Search::Error.new(params). I checked the whole codebase, and Search::Error doesn't exist — no file defines it, nothing else references it. 

Tracing git history, a 2022 commit (NSL-4135: Search error message...) fixed the sibling rescue StandardError branch to use the new run_empty_search_to_show_error helper, but left this StatementInvalid branch on the old, already-broken Search::Error reference. So for years, any malformed-SQL search error would have caused the rescue handler itself to blow up with NameError: uninitialized constant Search::Error, presumably surfacing as a raw 500 instead of the intended That query did not work message.

It's actually a double fix. Even setting the missing class aside, the old guard unless @search.present? meant that fallback rarely would have fired anyway: @search gets assigned early (run_local_search sets a lazily-evaluated Search::Base), and the actual SQL execution — where StatementInvalid would be raised — happens later during render_html/render_csv. So by the time the rescue runs, @search is typically already non-nil, and the guard would skip replacing it, leaving the broken search object to be re-rendered (likely re-triggering the same failure). Dropping the guard and calling run_empty_search_to_show_error unconditionally — exactly matching what the generic StandardError branch has done safely in production since 2022 — fixes both problems at once.



## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How to Test
I will put a link to a breaking search in the Jira - Anna actually found the problem and we have a link to her search.


## Tests
- [x] Unit tests (Claude)
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
