### PR TITLE
NSL-5856 - Add soft delete badge to name link text and implement test…

### DIFF
--- a/app/views/application/search_results/_name_as_part_of_instance_record.html.erb
+++ b/app/views/application/search_results/_name_as_part_of_instance_record.html.erb
@@ -24,6 +24,9 @@
           class="badge badge-duplicate"
         >duplicate</span>
       <% end %>
+      <% if search_result.deleted_at %>
+        <span class="badge badge-muted-orange">soft deleted</span>
+      <% end %>
   </a>
   </td>
   <td class="takes-focus width-5-percent filler">&nbsp;</td>

--- a/app/views/application/search_results/_name_as_part_of_instance_record.html.erb
+++ b/app/views/application/search_results/_name_as_part_of_instance_record.html.erb
@@ -24,7 +24,7 @@
           class="badge badge-duplicate"
         >duplicate</span>
       <% end %>
-      <% if search_result.deleted_at %>
+      <% if Rails.configuration.try(:soft_delete_enabled) && search_result.deleted_at %>
         <span class="badge badge-muted-orange">soft deleted</span>
       <% end %>
   </a>

--- a/app/views/application/search_results/link_texts/_name_link_text.html.erb
+++ b/app/views/application/search_results/link_texts/_name_link_text.html.erb
@@ -1,7 +1,4 @@
 <%= search_result[:full_name] %>
-<% if search_result[:deleted_at] %>
-  <span class="badge badge-muted-orange">soft deleted</span>
-<% end %>
 <%= "[#{search_result.name_status.name_without_brackets}]" unless search_result.name_status.legitimate? || search_result.name_status.manuscript? %>
 <%= search_result.name_tags.collect{|name_tag| name_tag.name}.join(', ') %>
 <% if search_result.duplicate? %>
@@ -9,4 +6,7 @@
     title="Record flagged as duplicate"
     class="badge badge-duplicate"
   >duplicate</span>
+<% end %>
+<% if search_result[:deleted_at] %>
+  <span class="badge badge-muted-orange">soft deleted</span>
 <% end %>

--- a/app/views/application/search_results/link_texts/_name_link_text.html.erb
+++ b/app/views/application/search_results/link_texts/_name_link_text.html.erb
@@ -1,4 +1,7 @@
 <%= search_result[:full_name] %>
+<% if search_result[:deleted_at] %>
+  <span class="badge badge-muted-orange">soft deleted</span>
+<% end %>
 <%= "[#{search_result.name_status.name_without_brackets}]" unless search_result.name_status.legitimate? || search_result.name_status.manuscript? %>
 <%= search_result.name_tags.collect{|name_tag| name_tag.name}.join(', ') %>
 <% if search_result.duplicate? %>

--- a/app/views/application/search_results/link_texts/_name_link_text.html.erb
+++ b/app/views/application/search_results/link_texts/_name_link_text.html.erb
@@ -7,6 +7,6 @@
     class="badge badge-duplicate"
   >duplicate</span>
 <% end %>
-<% if search_result[:deleted_at] %>
+<% if Rails.configuration.try(:soft_delete_enabled) && search_result[:deleted_at] %>
   <span class="badge badge-muted-orange">soft deleted</span>
 <% end %>

--- a/app/views/names/details/_meta.html.erb
+++ b/app/views/names/details/_meta.html.erb
@@ -9,6 +9,6 @@ Name #<%= @name.id %>
 <% if @name.api_name && @name.api_at %>
   <br>Record changed by: <%= "#{@name.api_name} #{formatted_timestamp(@name.api_at)}"%>
 <% end %>
-<% if @name.deleted_at %>
+<% if Rails.configuration.try(:soft_delete_enabled) && @name.deleted_at %>
   <br>Record soft deleted on: <%= formatted_timestamp(@name.deleted_at) %>
 <% end %>

--- a/app/views/names/details/_meta.html.erb
+++ b/app/views/names/details/_meta.html.erb
@@ -9,3 +9,6 @@ Name #<%= @name.id %>
 <% if @name.api_name && @name.api_at %>
   <br>Record changed by: <%= "#{@name.api_name} #{formatted_timestamp(@name.api_at)}"%>
 <% end %>
+<% if @name.deleted_at %>
+  <br>Record soft deleted on: <%= formatted_timestamp(@name.deleted_at) %>
+<% end %>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 23-July-2026
+  :jira_id: '5856'
+  :description: |-
+    Soft delete badge in name search results and soft delete datetime in name details tab
+- :date: 23-July-2026
   :jira_id: '5603'
   :description: |-
     Loader: Handle cases when misapplications are matched to an instance/reference with no iso_publication_date (bug from 7 July)

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.56
+appversion=5.1.4.57

--- a/test/views/application/search_results/link_texts/name_link_text_test.rb
+++ b/test/views/application/search_results/link_texts/name_link_text_test.rb
@@ -19,13 +19,22 @@
 require "test_helper"
 
 class NameLinkTextPartialTest < ActionView::TestCase
+  setup do
+    @original_soft_delete_enabled = Rails.configuration.try(:soft_delete_enabled)
+  end
+
+  teardown do
+    Rails.configuration.soft_delete_enabled = @original_soft_delete_enabled
+  end
+
   def render_link_text_for(name)
     render partial: "application/search_results/link_texts/name_link_text",
            locals: { search_result: name }
     rendered
   end
 
-  test "shows the soft deleted badge when the name has a deleted_at" do
+  test "shows the soft deleted badge when soft delete is enabled and the name has a deleted_at" do
+    Rails.configuration.soft_delete_enabled = true
     name = names(:another_species)
     name.update_column(:deleted_at, Time.current)
 
@@ -35,7 +44,19 @@ class NameLinkTextPartialTest < ActionView::TestCase
     assert_includes output, name.full_name
   end
 
+  test "does not show the soft deleted badge when soft delete is disabled even if the name has a deleted_at" do
+    Rails.configuration.soft_delete_enabled = false
+    name = names(:another_species)
+    name.update_column(:deleted_at, Time.current)
+
+    output = render_link_text_for(name)
+
+    assert_not_includes output, "soft deleted"
+    assert_select_in output, "span.badge.badge-muted-orange", false
+  end
+
   test "does not show the soft deleted badge when deleted_at is nil" do
+    Rails.configuration.soft_delete_enabled = true
     name = names(:another_species)
     assert_nil name.deleted_at
 

--- a/test/views/application/search_results/link_texts/name_link_text_test.rb
+++ b/test/views/application/search_results/link_texts/name_link_text_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+class NameLinkTextPartialTest < ActionView::TestCase
+  def render_link_text_for(name)
+    render partial: "application/search_results/link_texts/name_link_text",
+           locals: { search_result: name }
+    rendered
+  end
+
+  test "shows the soft deleted badge when the name has a deleted_at" do
+    name = names(:another_species)
+    name.update_column(:deleted_at, Time.current)
+
+    output = render_link_text_for(name)
+
+    assert_select_in output, "span.badge.badge-muted-orange", "soft deleted"
+    assert_includes output, name.full_name
+  end
+
+  test "does not show the soft deleted badge when deleted_at is nil" do
+    name = names(:another_species)
+    assert_nil name.deleted_at
+
+    output = render_link_text_for(name)
+
+    assert_not_includes output, "soft deleted"
+    assert_select_in output, "span.badge.badge-muted-orange", false
+  end
+
+  def assert_select_in(html, *args, &block)
+    assert_select(Nokogiri::HTML::DocumentFragment.parse(html), *args, &block)
+  end
+end

--- a/test/views/application/search_results/name_as_part_of_instance_record_test.rb
+++ b/test/views/application/search_results/name_as_part_of_instance_record_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+class NameAsPartOfInstanceRecordPartialTest < ActionView::TestCase
+  def render_record_for(name)
+    render partial: "application/search_results/name_as_part_of_instance_record",
+           locals: { search_result: name, give_me_focus: false }
+    rendered
+  end
+
+  test "shows the soft deleted badge when the name has a deleted_at" do
+    name = names(:another_species)
+    name.update_column(:deleted_at, Time.current)
+
+    output = render_record_for(name)
+
+    assert_select_in output, "span.badge.badge-muted-orange", "soft deleted"
+    assert_includes output, name.full_name
+  end
+
+  test "does not show the soft deleted badge when deleted_at is nil" do
+    name = names(:another_species)
+    assert_nil name.deleted_at
+
+    output = render_record_for(name)
+
+    assert_not_includes output, "soft deleted"
+    assert_select_in output, "span.badge.badge-muted-orange", false
+  end
+
+  def assert_select_in(html, *args, &block)
+    assert_select(Nokogiri::HTML::DocumentFragment.parse(html), *args, &block)
+  end
+end

--- a/test/views/application/search_results/name_as_part_of_instance_record_test.rb
+++ b/test/views/application/search_results/name_as_part_of_instance_record_test.rb
@@ -19,13 +19,22 @@
 require "test_helper"
 
 class NameAsPartOfInstanceRecordPartialTest < ActionView::TestCase
+  setup do
+    @original_soft_delete_enabled = Rails.configuration.try(:soft_delete_enabled)
+  end
+
+  teardown do
+    Rails.configuration.soft_delete_enabled = @original_soft_delete_enabled
+  end
+
   def render_record_for(name)
     render partial: "application/search_results/name_as_part_of_instance_record",
            locals: { search_result: name, give_me_focus: false }
     rendered
   end
 
-  test "shows the soft deleted badge when the name has a deleted_at" do
+  test "shows the soft deleted badge when soft delete is enabled and the name has a deleted_at" do
+    Rails.configuration.soft_delete_enabled = true
     name = names(:another_species)
     name.update_column(:deleted_at, Time.current)
 
@@ -35,7 +44,19 @@ class NameAsPartOfInstanceRecordPartialTest < ActionView::TestCase
     assert_includes output, name.full_name
   end
 
+  test "does not show the soft deleted badge when soft delete is disabled even if the name has a deleted_at" do
+    Rails.configuration.soft_delete_enabled = false
+    name = names(:another_species)
+    name.update_column(:deleted_at, Time.current)
+
+    output = render_record_for(name)
+
+    assert_not_includes output, "soft deleted"
+    assert_select_in output, "span.badge.badge-muted-orange", false
+  end
+
   test "does not show the soft deleted badge when deleted_at is nil" do
+    Rails.configuration.soft_delete_enabled = true
     name = names(:another_species)
     assert_nil name.deleted_at
 


### PR DESCRIPTION
## Description
- Soft delete badge in name search results
- Display the soft deleted date in name details tab audit section

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
