### PR TITLE
NSL-5806: Search: Fix search-target-reverts-to-Names-on-error bug introduced on 10 July

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -88,7 +88,7 @@ class SearchController < ApplicationController
 
   def run_empty_search_to_show_error(params)
     @empty_search = true
-    params[:query_target] = params[:original_query_target]
+    params[:query_target] = params[:original_query_target] || params[:query_target]
     @search = Search::Empty.new(params)
   end
 

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 23-July-2026
+  :jira_id: '5806'
+  :description: |-
+    Search: Fix search-target-reverts-to-Names-on-error bug introduced on 10 July
 - :date: 22-July-2026
   :jira_id: '5855'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.54
+appversion=5.1.4.55

--- a/test/controllers/search/errors/query_target_preserved_without_original_test.rb
+++ b/test/controllers/search/errors/query_target_preserved_without_original_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Regression test: run_empty_search_to_show_error used to unconditionally set
+# params[:query_target] = params[:original_query_target]. original_query_target
+# is only ever set for a "Names plus instances" search (see
+# handle_names_plus_instances_target), so for every other target this wiped
+# query_target to nil, and the error page's target button silently fell back
+# to the "Names" default (Search::EmptyParsedRequest#target_button_text) -
+# even though the user had actually searched, say, "References".
+#
+# The fix only falls back to query_target when original_query_target is
+# blank, so the user's actual target survives onto the error page.
+class SearchControllerQueryTargetPreservedWithoutOriginalTest < ActionController::TestCase
+  tests SearchController
+
+  test "an error during a non-'Names plus instances' search preserves the actual query target" do
+    SearchController.stub_any_instance(
+      :run_local_search,
+      -> { raise StandardError, "boom" }
+    ) do
+      get(:search,
+          params: { query_target: "References", query_string: "linnaeus" },
+          session: { username: "fred",
+                     user_full_name: "Fred Jones",
+                     groups: [] })
+    end
+
+    assert_response :success
+    assert_select "#search-target-button-text", /References/
+  end
+end


### PR DESCRIPTION
## Description
Claude says: This is a good fix. Before it, `run_empty_search_to_show_error` unconditionally did `params[:query_target] = params[:original_query_target]`, but `original_query_target `is only ever set in `handle_names_plus_instances_target` (for the Names plus instances target). For every other target, this silently wiped `query_target` to nil on error, and `Search::EmptyParsedRequest#target_button_text` falls back to `Names` — so a failed `References` or `Instances` search would reset the target dropdown to `Names` on the error page instead of showing what the user actually searched. The `|| params[:query_target] `fallback fixes that.

No existing test covered this case — `statement_invalid_test.rb` used `query_target: Names`, which happened to mask the bug since the buggy fallback and the correct value coincided. I added `test/controllers/search/errors/query_target_preserved_without_original_test.rb`, which forces an error on a References search and asserts the target button still reads References rather than resetting to Names.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
See Jira

## Tests
- [x] Unit tests (Claude)
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
