### PR TITLE
NSL-5857 - Add query directives for soft deleted names

### DIFF
--- a/app/views/names/advanced_search/_examples.html.erb
+++ b/app/views/names/advanced_search/_examples.html.erb
@@ -11,7 +11,7 @@
       {search_target: 'Names', search_string: "acacia",explanation: %Q(List names starting with "acacia".  Bare search is on names. 100 records is the default.)},
       {search_target: 'Names', search_string: "acacia limit: 1 offset: 99",explanation: %Q(List the 100th name starting with "acacia".)},
       {search_target: 'Names', search_string: "acacia limit: 100 offset: 200",explanation: %Q(List the 201st - 300th names starting with "acacia".)},
-      {search_target: 'Names', search_string: "acacia type:*", 
+      {search_target: 'Names', search_string: "acacia type:*",
        explanation: %Q(Also include common and cultivar names which are normally excluded (i.e. #{excc.sub(/\./,'')}).)},
       {search_target: 'Names', search_string: "*cacia", explanation: %Q(Find names containing "cacia". A trailing wildcard is added automatically. #{excc})},
       {search_target: 'Names', search_string: "acacia type:common,cultivar", explanation: %Q(Find just common or cultivar names exactly matching "acacia". #{incc})},
@@ -100,6 +100,8 @@
   <% [
       {search_target: 'Names', search_string: "is-a-parent: has-no-instances:",explanation: %Q(List names that have children but no instances.)},
       {search_target: 'Names', search_string: "has-a-second-parent:",explanation: %Q(List names that have a second parent.)},
+      {search_target: 'Names', search_string: "is-soft-deleted:",explanation: %Q(List names that are soft deleted.)},
+      {search_target: 'Names', search_string: "is-not-soft-deleted:",explanation: %Q(List names that are not soft deleted.)},
       {search_target: 'Names', search_string: "Grevillea has-a-second-parent:",explanation: %Q(List Grevilleas that have a second parent.)},
       {search_target: 'Names', search_string: "acacia is-orth-var-with-no-orth-var-instances:",explanation: %Q(List orth. var. acacias with no orth. var. instance.)},
       {search_target: 'Names', search_string: "*acacia is-orth-var-with-no-orth-var-instances:",explanation: %Q(List orth. var. names containing "acacia" with no orth. var. instance.)},

--- a/app/views/names/advanced_search/_field_help.html.erb
+++ b/app/views/names/advanced_search/_field_help.html.erb
@@ -46,7 +46,7 @@
       ].each do |val| %>
   <tr>
     <td class="width-20-percent">
-      <a href="javascript:void(0)" class="searchable-field width-100-percent" 
+      <a href="javascript:void(0)" class="searchable-field width-100-percent"
          data-search-directive="<%= val[:field_name] %>"
          title='Add "<%= val[:field_name] %>" field to search.'>
         <span class="blue"><%= val[:field_name] %></span>
@@ -82,7 +82,7 @@
       ].each do |val| %>
   <tr>
     <td class="width-20-percent">
-      <a href="javascript:void(0)" class="searchable-field width-100-percent" 
+      <a href="javascript:void(0)" class="searchable-field width-100-percent"
          data-search-directive="<%= val[:field_name] %>"
          title='Add "<%= val[:field_name] %>" field to search.'>
         <span class="blue"><%= val[:field_name] %></span>
@@ -111,7 +111,7 @@
       ].each do |val| %>
   <tr>
     <td class="width-20-percent">
-      <a href="javascript:void(0)" class="searchable-field width-100-percent" 
+      <a href="javascript:void(0)" class="searchable-field width-100-percent"
          data-search-directive="<%= val[:field_name] %>"
          title='Add "<%= val[:field_name] %>" field to search.'>
           <span class="blue"><%= val[:field_name] %></span>
@@ -138,7 +138,7 @@
       ].each do |val| %>
   <tr>
     <td class="width-20-percent">
-      <a href="javascript:void(0)" class="searchable-field width-100-percent" 
+      <a href="javascript:void(0)" class="searchable-field width-100-percent"
          data-search-directive="<%= val[:field_name] %>"
          title='Add "<%= val[:field_name] %>" field to search.'>
           <span class="blue"><%= val[:field_name] %></span>
@@ -174,6 +174,25 @@
   <% end %>
 </table>
 <br>
+
+<h6>Soft delete assertions</h6>
+<table class="table table-striped">
+  <% [
+      {field_name: 'is-soft-deleted:', description: "record is soft deleted"},
+      {field_name: 'is-not-soft-deleted:', description: "record is not soft deleted"},
+      ].each do |val| %>
+  <tr>
+    <td class="width-20-percent">
+      <a href="javascript:void(0)" class="searchable-field width-100-percent"
+         data-search-directive="<%= val[:field_name] %>"
+         title='Add "<%= val[:field_name] %>" field to search.'>
+          <span class="blue"><%= val[:field_name] %></span>
+        </a>
+    </td>
+    <td><%= val[:description].html_safe %></td>
+  </tr>
+  <% end %>
+</table>
 
 
 <h6>Parent-Child Queries</h6>
@@ -423,8 +442,8 @@
       {field_name: 'source-id-string:', description: "numeric ID as a string - so it takes wildcards and has a wildcard added to the tail, needs an argument"},
       ].each do |val| %>
   <tr>
-    <td class="width-20-percent"><a href="javascript:void(0)" 
-                                    data-search-directive="<%= val[:field_name] %>" 
+    <td class="width-20-percent"><a href="javascript:void(0)"
+                                    data-search-directive="<%= val[:field_name] %>"
                                     class="searchable-field width-100-percent" title='Add "<%= val[:field_name] %>" field to search.'>
         <span class="blue"><%= val[:field_name] %></span></a>
     </td>
@@ -437,5 +456,5 @@
 <%= render partial: 'help/case_and_wildcards_search' %>
 
 
-Note: When searches return Name records with their instances and synonymy, the <code>limit:</code> and <code>offset:</code> directives apply only to the 
+Note: When searches return Name records with their instances and synonymy, the <code>limit:</code> and <code>offset:</code> directives apply only to the
 Name records.

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 24-July-2026
+  :jira_id: '5857'
+  :description: |-
+    Query directives <code>is-soft-deleted:</code> and <code>is-not-soft-deleted:</code> to filter names on their `deleted_at` column
 - :date: 23-July-2026
   :jira_id: '5856'
   :description: |-

--- a/config/name-searches.yml
+++ b/config/name-searches.yml
@@ -95,6 +95,10 @@
     n2\n                                                    ON i2.name_id = n2.id\n
     \                                    WHERE  n2.id = n.id)\n             ) "
   :allow_common_and_cultivar: true
+'is-soft-deleted:':
+  :where_clause: " deleted_at is not null"
+'is-not-soft-deleted:':
+  :where_clause: " deleted_at is null"
 'comments:':
   :trailing_wildcard: true
   :leading_wildcard: true
@@ -361,7 +365,7 @@ from comment where comment.name_id = name.id)"
        and not ns.nom_inval
        and ns.name != 'isonym'
        and r.iso_publication_date is not null
-         and not exists 
+         and not exists
                        (select null
                           from name n2
                          inner join instance i2
@@ -431,17 +435,17 @@ from comment where comment.name_id = name.id)"
   :takes_no_arg: true,
   :where_clause: |2-
      id in ( select name.id
-                from tree_join_v tj 
-                     join name 
-                     on tj.name_id = name.id 
-                     join name_rank r 
-                     on name.name_rank_id = r.id  
+                from tree_join_v tj
+                     join name
+                     on tj.name_id = name.id
+                     join name_rank r
+                     on name.name_rank_id = r.id
                where current_tree_version_id = tree_version_id
-                 and tj.accepted_tree 
+                 and tj.accepted_tree
                  and not excluded
                  and r.name = 'Genus'
                  and not exists (select null
-                                   from tree_join_v tv2 
+                                   from tree_join_v tv2
                                   where  tv2.current_tree_version_id = tv2.tree_version_id
                                     and tv2.accepted_tree
                                     and tv2.parent_id = tj.element_link)
@@ -732,7 +736,7 @@ from comment where comment.name_id = name.id)"
    and i.instance_type_id in (select id from instance_type where name like '%orth%var%'))"
 'has-multiple-basionyms:':
   :where_clause: "id in
-  (select name_id from instance 
+  (select name_id from instance
     where exists (select null
                     from instance syn
                    where syn.cited_by_id = instance.id
@@ -793,7 +797,7 @@ from comment where comment.name_id = name.id)"
    and t.tree_path != npt.tree_path || '/'||t.tree_element_id
    and npt.name_path != regexp_replace(t.name_path,'/[^/]*$','')  ) ) "
 'first-parent-descendants-of-id:':
-  :where_clause: " id in 
+  :where_clause: " id in
 (WITH RECURSIVE subordinates AS (
 	SELECT
 		id
@@ -861,13 +865,13 @@ select instance.name_id
        ))"
 'first-instance-is-syn:':
   :takes_no_arg: true,
-  :where_clause: " id in 
+  :where_clause: " id in
 (select n.id
 from name n
 join instance i
      on n.id = i.name_id
 join instance_type t
-     on i.instance_type_id = t.id 
+     on i.instance_type_id = t.id
 join reference r
      on i.reference_id = r.id
 where t.relationship
@@ -885,8 +889,8 @@ where t.relationship
   :takes_no_arg: true,
   :allow_common_and_cultivar: true
   :where_clause: " id in (select id
-                            from name name_dupe_master 
-                           where id in (select duplicate_of_id 
+                            from name name_dupe_master
+                           where id in (select duplicate_of_id
                                           from name name_dupes
                                          where duplicate_of_id is not null)
                            and duplicate_of_id is not null)"
@@ -894,21 +898,21 @@ where t.relationship
   :takes_no_arg: true,
   :allow_common_and_cultivar: true
   :where_clause: " id in (select id
-                            from name name_dupe_master 
-                           where id in (select duplicate_of_id 
+                            from name name_dupe_master
+                           where id in (select duplicate_of_id
                                           from name name_dupes
                                          where duplicate_of_id is not null)
                            and duplicate_of_id is not null)"
 'novel-names-for-ref:':
-  :where_clause: " id in 
+  :where_clause: " id in
 (select n.id
-FROM instance 
+FROM instance
 INNER JOIN name n
-  ON n.id = instance.name_id 
-  INNER JOIN instance_type 
-  ON instance_type.id = instance.instance_type_id 
- WHERE instance.reference_id = ? 
-   AND instance_type.primary_instance = TRUE 
+  ON n.id = instance.name_id
+  INNER JOIN instance_type
+  ON instance_type.id = instance.instance_type_id
+ WHERE instance.reference_id = ?
+   AND instance_type.primary_instance = TRUE
   )"
 'tag:':
   :leading_wildcard: true

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.58
+appversion=5.1.4.59

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -2701,4 +2701,21 @@ parent_of_autonym_for_rank_validation:
   name_path: 'Plantae/test/parentofautonymrankvalidation'
   uri: autonym_rank_validation_2
 
+# Soft-deleted name used to exercise the `is-soft-deleted:` /
+# `is-not-soft-deleted:` search directives (config/name-searches.yml).
+a_soft_deleted_name:
+  <<: *DEFAULTS
+  name_element: softdeletia
+  simple_name: softdeletia
+  full_name: softdeletia
+  name_rank: species
+  name_status: legitimate
+  name_type: scientific
+  namespace: apni
+  parent_id: nil
+  family: a_family
+  name_path: 'Plantae/test/softdeletia'
+  uri: soft_deleted_name_1
+  deleted_at: 2020-01-01 00:00:00
+
 

--- a/test/models/search/on_name/soft_deleted/simple_test.rb
+++ b/test/models/search/on_name/soft_deleted/simple_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+require "test_helper"
+load "test/models/search/users.rb"
+load "test/models/search/on_name/test_helper.rb"
+
+class SearchOnNameSoftDeletedSimpleTest < ActiveSupport::TestCase
+  def search_ids(query_string)
+    params = ActiveSupport::HashWithIndifferentAccess.new(
+      query_target: "name",
+      query_string: query_string,
+      current_user: build_edit_user
+    )
+    search = Search::Base.new(params)
+    confirm_results_class(search.executed_query.results)
+    search.executed_query.results.collect(&:id)
+  end
+
+  test "is-soft-deleted: includes a soft deleted name" do
+    assert_includes search_ids("is-soft-deleted:"),
+                    names(:a_soft_deleted_name).id,
+                    "Expected the soft deleted name in the results"
+  end
+
+  test "is-soft-deleted: excludes a name that is not soft deleted" do
+    refute_includes search_ids("is-soft-deleted:"),
+                    names(:the_regnum).id,
+                    "Expected a live name to be excluded from the results"
+  end
+
+  test "is-not-soft-deleted: includes a name that is not soft deleted" do
+    assert_includes search_ids("is-not-soft-deleted:"),
+                    names(:the_regnum).id,
+                    "Expected a live name in the results"
+  end
+
+  test "is-not-soft-deleted: excludes a soft deleted name" do
+    refute_includes search_ids("is-not-soft-deleted:"),
+                    names(:a_soft_deleted_name).id,
+                    "Expected the soft deleted name to be excluded"
+  end
+
+  test "the two directives return disjoint result sets" do
+    deleted_ids = search_ids("is-soft-deleted:")
+    live_ids = search_ids("is-not-soft-deleted:")
+    assert_empty deleted_ids & live_ids,
+                 "A name should never be both soft deleted and not soft deleted"
+  end
+end


### PR DESCRIPTION
## Description
Add a `is-soft-deleted` and `is-not-soft-deleted` search directive for name search

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
