### PR TITLE
NSL-5857 - Add query directives for soft deleted instances

### DIFF
--- a/app/models/search/on_instance/field_rule.rb
+++ b/app/models/search/on_instance/field_rule.rb
@@ -57,8 +57,8 @@ from comment where comment.instance_id = instance.id)",
     "page:" => { where_clause: " lower(page) like lower(?)" },
     "page-qualifier:" => { where_clause:
                                  " lower(page_qualifier) like lower(?)" },
-    
-    "show-profiles:" => { where_clause: " exists (select null 
+
+    "show-profiles:" => { where_clause: " exists (select null
                                  from profile_item
                                  join profile_text as pt on pt.id = profile_item.profile_text_id
                                  where profile_item.instance_id = instance.id
@@ -202,6 +202,10 @@ from comment where comment.instance_id = instance.id)",
                                       takes_no_arg: true},
     "is-not-cited-by-an-instance:" => { where_clause: " cited_by_id is null",
                                         takes_no_arg: true},
+    "is-soft-deleted:" => { where_clause: " deleted_at is not null",
+                            takes_no_arg: true},
+    "is-not-soft-deleted:" => { where_clause: " deleted_at is null",
+                                takes_no_arg: true},
     "verbatim-name-exact:" => { where_clause:
                                  "lower(verbatim_name_string) like lower(?) " },
     "verbatim-name:" => { where_clause:
@@ -249,7 +253,7 @@ from comment where comment.instance_id = instance.id)",
                                                              'orth. var.'))" ,
                        takes_no_arg: true},
     "species-or-below-syn-with-genus-or-above:" =>
-    { where_clause: 
+    { where_clause:
       " instance.id in
       (
      SELECT i.id
@@ -345,13 +349,13 @@ from instance i
     "name-status-not:" => { where_clause: %[ id in (select i.id from instance i join name n on i.name_id = n.id join name_status ns on n.name_status_id = ns.id and lower(ns.name) not like lower(?))] },
     "syn-conflicts-with-loader-batch:" => { where_clause: " id in (
    select instance.id
-  from loader_name ln 
+  from loader_name ln
        join loader_name_match lnm
        on ln.id = lnm.loader_name_id
        join instance
-       on lnm.name_id = instance.name_id 
-       join tree_join_v tjv 
-       on instance.id = tjv.instance_id 
+       on lnm.name_id = instance.name_id
+       join tree_join_v tjv
+       on instance.id = tjv.instance_id
        join loader_batch lb
        on ln.loader_batch_id = lb.id
        join name

--- a/app/views/instances/advanced_search/_examples.html.erb
+++ b/app/views/instances/advanced_search/_examples.html.erb
@@ -233,6 +233,12 @@
        explanation: %Q(Instances for names containing "morna" that
        synonymise a name ranked species or below with a name that is genus or
        above..)},
+      {search_target: 'Instances',
+       search_string: "is-soft-deleted:",
+       explanation: %Q(Instances that are soft deleted.)},
+      {search_target: 'Instances',
+       search_string: "is-not-soft-deleted:",
+       explanation: %Q(Instances that are not soft deleted.)},
       ].each do |val| %>
   <tr>
     <td class="width-30-percent">

--- a/app/views/instances/advanced_search/_field_help.html.erb
+++ b/app/views/instances/advanced_search/_field_help.html.erb
@@ -263,6 +263,8 @@ word "darwin" followed by a space, one or more other characters followed by "bar
          {field_name: 'is-standalone:', description: "Instance type is standalone"},
          {field_name: 'is-not-standalone:', description: "Instance type is not standalone"},
          {field_name: 'is-tax-nov-for-orth-var-name:', description: "Instance is a tax. nov. type but the name is an orth. var."},
+         {field_name: 'is-soft-deleted:', description: "Instance is soft deleted"},
+         {field_name: 'is-not-soft-deleted:', description: "Instance is not soft deleted"},
          {field_name: 'species-or-below-syn-with-genus-or-above:',
           description: "Instance synonymises a name ranked species or below with a name that is genus or above."},
          {field_name: 'nov-lacks-replaced-syn:',

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,11 +1,15 @@
 - :date: 24-July-2026
+  :jira_id: '5857'
+  :description: |-
+    Query directives <code>is-soft-deleted:</code> and <code>is-not-soft-deleted:</code> to filter instances on their `deleted_at` column
+- :date: 24-July-2026
   :jira_id: '5557'
   :description: |-
     Reference search: Add two display-title directives
 - :date: 24-July-2026
   :jira_id: '5602'
   :description: |-
-    Loader: Improve Loader Name search directive <code>name-match-no-primary:</code> 
+    Loader: Improve Loader Name search directive <code>name-match-no-primary:</code>
 - :date: 24-July-2026
   :jira_id: '5857'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.61
+appversion=5.1.4.62

--- a/test/controllers/search/references/on_default/with_instances_test.rb
+++ b/test/controllers/search/references/on_default/with_instances_test.rb
@@ -31,7 +31,7 @@ class SearchRefsOnDefaultWithInstancesTest < ActionController::TestCase
                    groups: [] })
     assert_response :success
     assert_select "#search-results-summary",
-                  /6 records\b/,
-                  "Should find 6 records"
+                  /7 records\b/,
+                  "Should find 7 records"
   end
 end

--- a/test/fixtures/instances.yml
+++ b/test/fixtures/instances.yml
@@ -944,6 +944,6 @@ a_soft_deleted_instance:
   name: metrosideros_costata_gaertn
   instance_type: comb_nov
   verbatim_name_string: verbatim
-  page: "soft-deleted 1"
+  page: exclude-from-ordering-test
   deleted_at: <%= Time.now %>
 

--- a/test/fixtures/instances.yml
+++ b/test/fixtures/instances.yml
@@ -80,7 +80,7 @@ triodia_in_brassard:
   updated_at: <%= Time.now + (24*60*60) %>
   page: "xx 200,300"
   page_qualifier: qualified
- 
+
 # Standalone instance
 britten_created_angophora_costata:
   <<: *DEFAULTS
@@ -128,9 +128,9 @@ xyz_costata_is_synonym_of_angophora_costata:
   this_is_cited_by: britten_created_angophora_costata
   this_cites: gaertner_created_metrosideros_costata
   instance_type: nomenclatural_synonym
-  verbatim_name_string: 
+  verbatim_name_string:
   page: xx,20,1000
- 
+
 # Relationship instance - unpublished citation
 rusty_gum_is_a_common_name_of_angophora_costata:
   <<: *DEFAULTS
@@ -140,7 +140,7 @@ rusty_gum_is_a_common_name_of_angophora_costata:
   instance_type: vernacular_name
   verbatim_name_string: rusty gum
   page: "41"
- 
+
 # Relationship instance - invalid unpublished citation with unmatched reference
 invalid_unpublished_citation_with_unmatched_reference:
   <<: *DEFAULTS
@@ -166,7 +166,7 @@ invalid_publication_standalone_instance:
 no_source_system:
   <<: *DEFAULTS
   reference: de_fructibus_et_seminibus_plantarum
-  name: angophora_costata 
+  name: angophora_costata
   instance_type: invalid_publication
   verbatim_name_string: verbatim
   page: "3"
@@ -694,7 +694,7 @@ pro_parte_nomenclatural_synonym_instance:
   verbatim_name_string: verbatim20
   created_at: <%= Time.now + (24*60*60) %>
   updated_at: <%= Time.now + (24*60*60) %>
- 
+
 # Standalone instance
 has_no_page_bhl_url_verbatim_name_string:
   <<: *DEFAULTS
@@ -725,7 +725,7 @@ tax_nov_for_an_orth_var:
   instance_type: tax_nov
   page: 9999999999
   verbatim_name_string: verbatim23
- 
+
 # Standalone instance
 has_apc_dist_note:
   <<: *DEFAULTS
@@ -797,7 +797,7 @@ inst_genus_or_above_to_be_synomised:
   page: exclude-from-ordering-test
   verbatim_name_string: verbatim8
 
-# standalone for name earliest_instance_not_primary: 
+# standalone for name earliest_instance_not_primary:
 inst_for_name_earliest_instance_not_primary:
   <<: *DEFAULTS
   reference: ref_4_genus_or_above_to_be_synonym
@@ -817,7 +817,7 @@ name_in_secondary_ref_marked_as_basionym_synonym:
   page: exclude-from-ordering-test
   verbatim_name_string: verbatim11
 
-# standalone 
+# standalone
 secondary_ref_citation:
   <<: *DEFAULTS
   reference: dummy_reference_for_eflora_service
@@ -925,7 +925,7 @@ instance_for_name_in_taxonomy:
 instance_for_name_in_taxonomy:
   <<: *DEFAULTS
   reference: syntrinema_genus_novum
-  name: ptychocaryum_ghaeri 
+  name: ptychocaryum_ghaeri
   instance_type: comb_nov
   source_id_string: gcmd
   page: exclude-from-ordering-test
@@ -938,11 +938,10 @@ darwinia_sp_7_in_briggs_and_leigh_1996:
   page: exclude-from-ordering-test
   verbatim_name_string: l
 
-# Soft deleted standalone instance - used by the is-soft-deleted: search tests
 a_soft_deleted_instance:
   <<: *DEFAULTS
   reference: de_fructibus_et_seminibus_plantarum
-  name: angophora_costata
+  name: metrosideros_costata_gaertn
   instance_type: comb_nov
   verbatim_name_string: verbatim
   page: "soft-deleted 1"

--- a/test/fixtures/instances.yml
+++ b/test/fixtures/instances.yml
@@ -938,3 +938,13 @@ darwinia_sp_7_in_briggs_and_leigh_1996:
   page: exclude-from-ordering-test
   verbatim_name_string: l
 
+# Soft deleted standalone instance - used by the is-soft-deleted: search tests
+a_soft_deleted_instance:
+  <<: *DEFAULTS
+  reference: de_fructibus_et_seminibus_plantarum
+  name: angophora_costata
+  instance_type: comb_nov
+  verbatim_name_string: verbatim
+  page: "soft-deleted 1"
+  deleted_at: <%= Time.now %>
+

--- a/test/models/search/on_instance/name_status_not/simple_test.rb
+++ b/test/models/search/on_instance/name_status_not/simple_test.rb
@@ -28,7 +28,7 @@ class SearchOnInstanceNameStatusNotSimpleTest < ActiveSupport::TestCase
       current_user: build_edit_user
     )
     search = Search::Base.new(params)
-    assert search.executed_query.results.size == 35,
-      "35 expected not #{search.executed_query.results.size}"
+    assert search.executed_query.results.size == 36,
+      "36 expected not #{search.executed_query.results.size}"
   end
 end

--- a/test/models/search/on_instance/soft_deleted/simple_test.rb
+++ b/test/models/search/on_instance/soft_deleted/simple_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+
+# Search model tests for the is-soft-deleted: / is-not-soft-deleted:
+# instance search directives.
+class SearchOnInstanceSoftDeletedSimpleTest < ActiveSupport::TestCase
+  def search_ids(query_string)
+    params = ActiveSupport::HashWithIndifferentAccess.new(
+      query_target: "instance",
+      query_string: query_string,
+      current_user: build_edit_user
+    )
+    search = Search::Base.new(params)
+    search.executed_query.results.collect(&:id)
+  end
+
+  test "is-soft-deleted: includes a soft deleted instance" do
+    assert_includes search_ids("is-soft-deleted:"),
+                    instances(:a_soft_deleted_instance).id,
+                    "Expected the soft deleted instance in the results"
+  end
+
+  test "is-soft-deleted: excludes an instance that is not soft deleted" do
+    refute_includes search_ids("is-soft-deleted:"),
+                    instances(:gaertner_created_metrosideros_costata).id,
+                    "Expected a live instance to be excluded from the results"
+  end
+
+  test "is-not-soft-deleted: includes an instance that is not soft deleted" do
+    assert_includes search_ids("is-not-soft-deleted:"),
+                    instances(:gaertner_created_metrosideros_costata).id,
+                    "Expected a live instance in the results"
+  end
+
+  test "is-not-soft-deleted: excludes a soft deleted instance" do
+    refute_includes search_ids("is-not-soft-deleted:"),
+                    instances(:a_soft_deleted_instance).id,
+                    "Expected the soft deleted instance to be excluded"
+  end
+
+  test "the two directives return disjoint result sets" do
+    deleted_ids = search_ids("is-soft-deleted:")
+    live_ids = search_ids("is-not-soft-deleted:")
+    assert_empty deleted_ids & live_ids,
+                 "An instance should never be both soft deleted and not " \
+                 "soft deleted"
+  end
+end


### PR DESCRIPTION
## Description
 Implement `is-soft-deleted` and `is-not-soft-deleted` query directives for instance search

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
