### PR TITLE
NSL-5557: Reference search: Add two display-title directives

### DIFF
--- a/app/models/search/reference/field_rule.rb
+++ b/app/models/search/reference/field_rule.rb
@@ -223,5 +223,12 @@ inner join ref_type xcrt on xrt.id = xcrt.parent_id))",
     on parent.ref_type_id = prt.id
  where rt.name  = 'Unknown'
    and prt.name = 'Journal')"},
+    "display-title:" => { trailing_wildcard: true,
+                          leading_wildcard: true,
+                          where_clause:
+                                 " lower(display_title) like lower(?)" },
+    "title-does-not-match-display-title:" => { 
+                          takes_no_arg: true,
+                          where_clause: " display_title != title " },
   }.freeze
 end

--- a/app/views/references/advanced_search/_directives_list.erb
+++ b/app/views/references/advanced_search/_directives_list.erb
@@ -14,6 +14,7 @@
       {field_name: 'citation-exact:', description: "search citation with no tokenization, and no wildcards unless you supply them"},
       {field_name: 'title:', description: "title, with trailing wildcard added automatically"},
       {field_name: 'title-exact:', description: "title"},
+      {field_name: 'display-title:', description: "display title, with leading and trailing wildcards added automatically"},
       ].each do |val| %>
   <tr>
     <td class="width-20-percent">
@@ -236,6 +237,7 @@ in the following formats:</p>
        description: "Publication date is 4 digits alone or 4 digits within
        parentheses."},
        {field_name: 'has-no-direct-or-child-instances:', description: "References that have no instance and no children with instances. Does <b>not</b> check beyond first generation of children."},
+       {field_name: 'title-does-not-match-display-title:', description: "References in which the title and display title are not the same. Takes no arguments"},
       ].each do |val| %>
   <tr>
     <td class="width-20-percent">

--- a/app/views/references/tabs/_tab_show_1.html.erb
+++ b/app/views/references/tabs/_tab_show_1.html.erb
@@ -29,6 +29,10 @@
               title: "Search for the #{label_string}",
               tabindex: increment_tab_index) %>
 <% end %>
+<% unless @reference.title == @reference.display_title %>
+<br>
+<%= render partial: 'detail_line', locals: {info: @reference.display_title, label: 'Display Title'} %>
+<% end %>
 
 <% if @reference.duplicate_of.present? %>
   <br>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 24-July-2026
+  :jira_id: '5557'
+  :description: |-
+    Reference search: Add two display-title directives
+- :date: 24-July-2026
   :jira_id: '5602'
   :description: |-
     Loader: Improve Loader Name search directive <code>name-match-no-primary:</code> 

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.60
+appversion=5.1.4.61

--- a/test/controllers/references/tabs/for_editor/show_details_tab_hides_display_title_when_same_test.rb
+++ b/test/controllers/references/tabs/for_editor/show_details_tab_hides_display_title_when_same_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single reference controller test.
+#
+# app/views/references/tabs/_tab_show_1.html.erb should NOT add a
+# "Display Title" detail_line when title and display_title are the same
+# (the normal case - Reference#set_defaults copies title into
+# display_title whenever display_title is blank).
+class ReferenceShowEditorDetailsTabHidesDisplayTitleWhenSameTest < ActionController::TestCase
+  tests ReferencesController
+  setup do
+    @reference = references(:a_book)
+  end
+
+  test "hides the Display Title line when title and display_title are the same" do
+    @request.headers["Accept"] = "application/javascript"
+    get(:show,
+        params: { id: @reference.id, tab: "tab_show_1" },
+        session: { username: "fred",
+                   user_full_name: "Fred Jones",
+                   groups: ["edit"] })
+    assert_response :success
+    assert_no_match(/Display Title/, response.body)
+  end
+end

--- a/test/controllers/references/tabs/for_editor/show_details_tab_shows_display_title_when_different_test.rb
+++ b/test/controllers/references/tabs/for_editor/show_details_tab_shows_display_title_when_different_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single reference controller test.
+#
+# app/views/references/tabs/_tab_show_1.html.erb adds a "Display Title"
+# detail_line when @reference.title != @reference.display_title.
+# references(:simple) has title "  Simple  " and display_title
+# "Display Title", so the two clearly differ.
+class ReferenceShowEditorDetailsTabShowsDisplayTitleWhenDifferentTest < ActionController::TestCase
+  tests ReferencesController
+  setup do
+    @reference = references(:simple)
+  end
+
+  test "shows a Display Title line when title and display_title differ" do
+    @request.headers["Accept"] = "application/javascript"
+    get(:show,
+        params: { id: @reference.id, tab: "tab_show_1" },
+        session: { username: "fred",
+                   user_full_name: "Fred Jones",
+                   groups: ["edit"] })
+    assert_response :success
+    assert_match(/Display Title/, response.body)
+    assert_match(/#{Regexp.escape(@reference.display_title)}/, response.body)
+  end
+end

--- a/test/models/search/on_reference/display_title/simple_negative_test.rb
+++ b/test/models/search/on_reference/display_title/simple_negative_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+
+# Single Search model test for Reference target.
+class SearchOnReferenceDisplayTitleSimpleNegativeTest < ActiveSupport::TestCase
+  test "search on reference display-title simple negative" do
+    reference = references(:simple)
+    params =  ActiveSupport::HashWithIndifferentAccess
+              .new(query_target: "reference",
+                   query_string: "display-title: zzz-text-not-present-anywhere",
+                   current_user: build_edit_user)
+    search = Search::Base.new(params)
+    assert search.executed_query.results.is_a?(ActiveRecord::Relation),
+           "Results should be an ActiveRecord::Relation."
+    assert_not_includes search.executed_query.results.map(&:id), reference.id
+  end
+end

--- a/test/models/search/on_reference/display_title/simple_positive_test.rb
+++ b/test/models/search/on_reference/display_title/simple_positive_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+
+# Single Search model test for Reference target.
+#
+# references(:simple) has title "  Simple  " and a deliberately different
+# display_title "Display Title" - good for exercising display-title:
+# independently of title:.
+class SearchOnReferenceDisplayTitleSimplePositiveTest < ActiveSupport::TestCase
+  test "search on reference display-title simple positive" do
+    reference = references(:simple)
+    params =  ActiveSupport::HashWithIndifferentAccess
+              .new(query_target: "reference",
+                   query_string: "display-title: #{reference.display_title}",
+                   current_user: build_edit_user)
+    search = Search::Base.new(params)
+    assert search.executed_query.results.is_a?(ActiveRecord::Relation),
+           "Results should be an ActiveRecord::Relation."
+    assert_includes search.executed_query.results.map(&:id), reference.id
+  end
+end

--- a/test/models/search/on_reference/display_title/wildcard_test.rb
+++ b/test/models/search/on_reference/display_title/wildcard_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+
+# Single Search model test for Reference target.
+#
+# display-title: sets both leading_wildcard and trailing_wildcard, unlike
+# title: which only sets trailing_wildcard. Searching for a fragment from
+# the *middle* of the display_title (neither a prefix nor the whole value)
+# only matches if the leading wildcard is really being applied - a
+# trailing-wildcard-only search would not find it.
+class SearchOnReferenceDisplayTitleWildcardTest < ActiveSupport::TestCase
+  test "search on reference display-title matches a mid-string fragment" do
+    reference = references(:simple)
+    assert_equal "Display Title", reference.display_title
+
+    params =  ActiveSupport::HashWithIndifferentAccess
+              .new(query_target: "reference",
+                   query_string: "display-title: splay Tit",
+                   current_user: build_edit_user)
+    search = Search::Base.new(params)
+    assert search.executed_query.results.is_a?(ActiveRecord::Relation),
+           "Results should be an ActiveRecord::Relation."
+    assert_includes search.executed_query.results.map(&:id), reference.id
+  end
+end

--- a/test/models/search/on_reference/title_does_not_match_display_title/excludes_when_same_test.rb
+++ b/test/models/search/on_reference/title_does_not_match_display_title/excludes_when_same_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+
+# Single Search model test for Reference target.
+class SearchOnReferenceTitleDoesNotMatchDisplayTitleExcludesWhenSameTest < ActiveSupport::TestCase
+  test "excludes a reference whose title and display_title are the same" do
+    reference = references(:a_book)
+    assert_equal reference.title, reference.display_title
+
+    params =  ActiveSupport::HashWithIndifferentAccess
+              .new(query_target: "reference",
+                   query_string: "title-does-not-match-display-title:",
+                   current_user: build_edit_user)
+    search = Search::Base.new(params)
+    assert search.executed_query.results.is_a?(ActiveRecord::Relation),
+           "Results should be an ActiveRecord::Relation."
+    assert_not_includes search.executed_query.results.map(&:id), reference.id
+  end
+end

--- a/test/models/search/on_reference/title_does_not_match_display_title/matches_when_different_test.rb
+++ b/test/models/search/on_reference/title_does_not_match_display_title/matches_when_different_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+
+# Single Search model test for Reference target.
+#
+# title-does-not-match-display-title: takes no argument - Reference#title
+# and #display_title are both NOT NULL, and Reference#set_defaults copies
+# title into display_title whenever display_title is blank, so the two
+# only ever diverge when display_title has been explicitly overridden, or
+# title was edited afterwards without updating display_title.
+class SearchOnReferenceTitleDoesNotMatchDisplayTitleMatchesWhenDifferentTest < ActiveSupport::TestCase
+  test "matches a reference whose title and display_title differ" do
+    reference = references(:simple)
+    assert_not_equal reference.title, reference.display_title
+
+    params =  ActiveSupport::HashWithIndifferentAccess
+              .new(query_target: "reference",
+                   query_string: "title-does-not-match-display-title:",
+                   current_user: build_edit_user)
+    search = Search::Base.new(params)
+    assert search.executed_query.results.is_a?(ActiveRecord::Relation),
+           "Results should be an ActiveRecord::Relation."
+    assert_includes search.executed_query.results.map(&:id), reference.id
+  end
+end


### PR DESCRIPTION
## Description
Add two directives - display-title and  title-does-not-match-display-title.  See JIra for details.  Also show the display title on the details tab if it does not match the title.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
See Jira

## Tests
- [x] Unit tests - Claude
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
