### PR TITLE
NSL-5860 - Add API name and date search functionality with correspond…

### DIFF
--- a/app/views/names/advanced_search/_examples.html.erb
+++ b/app/views/names/advanced_search/_examples.html.erb
@@ -281,6 +281,55 @@
 </table>
 <br>
 
+<h5 class="">API change searches</h5>
+<table class="example-searches table table-striped">
+  <% [
+      {search_target: 'Names',
+       search_string: "has-api-name:",
+       explanation: %Q(Names that have been changed by an API.)},
+      {search_target: 'Names',
+       search_string: "has-no-api-name:",
+       explanation: %Q(Names that have never been changed by an API.)},
+      {search_target: 'Names',
+       search_string: "api-name: jira-sync",
+       explanation: %Q(Names last changed by an API whose name contains "jira-sync". Case-insensitive, with wildcards added at both ends.)},
+      {search_target: 'Names',
+       search_string: "api-at: 27-07-2026",
+       explanation: %Q(Names changed by an API on 27 July 2026.)},
+      {search_target: 'Names',
+       search_string: "api-at: 07-2026",
+       explanation: %Q(Names changed by an API in July 2026 - the date is matched with wildcards at both ends.)},
+      {search_target: 'Names',
+       search_string: "api-at: 2026",
+       explanation: %Q(Names changed by an API in 2026.)},
+      {search_target: 'Names',
+       search_string: "api-at-after: 26-07-2026",
+       explanation: %Q(Names changed by an API after 26 July 2026, excluding the 26th itself.)},
+      {search_target: 'Names',
+       search_string: "api-at-before: 28-07-2026",
+       explanation: %Q(Names changed by an API before 28 July 2026, excluding the 28th itself.)},
+      {search_target: 'Names',
+       search_string: "api-at-after: 26-07-2026 api-at-before: 28-07-2026",
+       explanation: %Q(Names changed by an API within a date range - here, 27 July 2026 only.)},
+      {search_target: 'Names',
+       search_string: "api-name: jira-sync api-at-after: 30-06-2026",
+       explanation: %Q(Names changed by the "jira-sync" API after 30 June 2026.)},
+     ].each do |val| %>
+  <tr>
+    <td class="width-30-percent">
+      <%= link_to(val[:search_string],
+                  search_path(query_string: val[:search_string],
+                  query_target: val[:search_target]),
+                  class:'blue',
+                  title: "Run the described search.")
+      %>
+    </td>
+    <td><%= val[:explanation].html_safe %></td>
+  </tr>
+  <% end %>
+</table>
+<br>
+
 
 </div>
 

--- a/app/views/names/advanced_search/_field_help.html.erb
+++ b/app/views/names/advanced_search/_field_help.html.erb
@@ -430,6 +430,32 @@
 </table>
 <br>
 
+<h5>API changes</h5>
+<p>Records changed via the API record the name of the API that changed them and when it happened.</p>
+<p>Dates are entered as <code>dd-mm-yyyy</code> in Australia/Melbourne time.</p>
+<table class="table table-striped">
+  <% [
+      {field_name: 'api-name:', description: "name of the API that last changed the record, case-insensitive, wildcards added at both ends"},
+      {field_name: 'has-api-name:', description: "record has been changed by an API; no arguments"},
+      {field_name: 'has-no-api-name:', description: "record has never been changed by an API; no arguments"},
+      {field_name: 'api-at:', description: %Q(date the API last changed the record, as <code>dd-mm-yyyy</code>. Wildcards are added at both ends, so <code>07-2026</code> matches a month and <code>2026</code> matches a year)},
+      {field_name: 'api-at-after:', description: "changed by an API after the given date, excluding the date itself"},
+      {field_name: 'api-at-before:', description: "changed by an API before the given date, excluding the date itself -- tip: combine with api-at-after: for a date range"},
+      ].each do |val| %>
+  <tr>
+    <td class="width-20-percent">
+        <a href="javascript:void(0)" class="searchable-field width-100-percent"
+           data-search-directive="<%= val[:field_name] %>"
+           title='Add "<%= val[:field_name] %>" field to search.'>
+          <span class="blue"><%= val[:field_name] %></span>
+        </a>
+    </td>
+    <td><%= val[:description].html_safe %></td>
+  </tr>
+  <% end %>
+</table>
+<br>
+
 <%= render partial: 'comments/advanced_search/help' %>
 <%= render partial: 'help/id_search_help' %>
 <h5>Source of migrated records</h5>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 27-July-2026
+  :jira_id: '5860'
+  :description: |-
+    Query directives for api_name and api_at in name search
+- :date: 27-July-2026
   :jira_id: '3228'
   :description: |-
     Name Delete: Add a 2 second delay before checking Name is deleted, also make the error message more neutral

--- a/config/name-searches.yml
+++ b/config/name-searches.yml
@@ -1,4 +1,18 @@
 ---
+'api-name:':
+  :where_clause: " lower(api_name) like ? "
+  :trailing_wildcard: true
+  :leading_wildcard: true
+'api-at:':
+  :where_clause: " to_char(api_at at time zone 'Australia/Melbourne', 'dd-mm-yyyy') like
+    ? "
+  :trailing_wildcard: true
+  :leading_wildcard: true
+'api-at-after:':
+  :where_clause: " (api_at at time zone 'Australia/Melbourne') >= to_date(?, 'dd-mm-yyyy')
+    + interval '1 day' "
+'api-at-before:':
+  :where_clause: " (api_at at time zone 'Australia/Melbourne') < to_date(?, 'dd-mm-yyyy') "
 'autonym-name-mismatch:':
   :where_clause: |-
     id in (select name.id
@@ -27,6 +41,10 @@
 'is-not-a-parent:':
   :where_clause: " not exists       (select null from name child where child.parent_id
     = name.id) "
+'has-api-name:':
+  :where_clause: " api_name is not null"
+'has-no-api-name:':
+  :where_clause: " api_name is null"
 'has-no-parent:':
   :where_clause: " parent_id is null"
 'has-parent:':

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.64
+appversion=5.1.4.65

--- a/test/models/search/on_name/api_at/simple_test.rb
+++ b/test/models/search/on_name/api_at/simple_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+require "test_helper"
+load "test/models/search/users.rb"
+load "test/models/search/on_name/test_helper.rb"
+
+class SearchOnNameApiAtSimpleTest < ActiveSupport::TestCase
+
+  DISPLAY_ZONE = "Australia/Melbourne"
+
+  setup do
+    Time.use_zone(DISPLAY_ZONE) do
+      names(:the_regnum).update_columns(api_at: Time.zone.parse("2026-07-27 09:00"))
+      names(:a_family).update_columns(api_at: Time.zone.parse("2026-08-15 12:00"))
+    end
+  end
+
+  def search_ids(query_string)
+    params = ActiveSupport::HashWithIndifferentAccess.new(
+      query_target: "name",
+      query_string: query_string,
+      current_user: build_edit_user
+    )
+    search = Search::Base.new(params)
+    confirm_results_class(search.executed_query.results)
+    search.executed_query.results.collect(&:id)
+  end
+
+  test "api-at: matches a name changed on that date" do
+    assert_includes search_ids("api-at: 27-07-2026"),
+                    names(:the_regnum).id,
+                    "Expected the name changed on 27-07-2026 in the results"
+  end
+
+  test "api-at: excludes a name changed on another date" do
+    refute_includes search_ids("api-at: 27-07-2026"),
+                    names(:a_family).id,
+                    "Expected the name changed on 15-08-2026 to be excluded"
+  end
+
+  test "api-at: uses the display timezone, not UTC" do
+    refute_includes search_ids("api-at: 26-07-2026"),
+                    names(:the_regnum).id,
+                    "9am on the 27th in #{DISPLAY_ZONE} must not match the 26th"
+  end
+
+  test "api-at: matches on month and year alone" do
+    assert_includes search_ids("api-at: 07-2026"),
+                    names(:the_regnum).id,
+                    "Expected a month-and-year search to match"
+    refute_includes search_ids("api-at: 07-2026"),
+                    names(:a_family).id,
+                    "Expected a name changed in August to be excluded"
+  end
+
+  test "api-at: matches on year alone" do
+    ids = search_ids("api-at: 2026")
+    assert_includes ids, names(:the_regnum).id,
+                    "Expected a year search to match the July name"
+    assert_includes ids, names(:a_family).id,
+                    "Expected a year search to match the August name"
+  end
+
+  test "api-at: excludes names that have never been changed by the api" do
+    refute_includes search_ids("api-at: 2026"),
+                    names(:a_species).id,
+                    "Expected a name with no api_at to be excluded"
+  end
+
+  test "api-at-after: excludes the named day itself" do
+    refute_includes search_ids("api-at-after: 27-07-2026"),
+                    names(:the_regnum).id,
+                    "Expected after: to exclude names changed on that same day"
+  end
+
+  test "api-at-after: includes a name changed on a later day" do
+    ids = search_ids("api-at-after: 26-07-2026")
+    assert_includes ids, names(:the_regnum).id,
+                    "Expected the 27th to be after the 26th"
+    assert_includes ids, names(:a_family).id,
+                    "Expected the 15th of August to be after the 26th of July"
+  end
+
+  test "api-at-before: excludes the named day itself" do
+    refute_includes search_ids("api-at-before: 27-07-2026"),
+                    names(:the_regnum).id,
+                    "Expected before: to exclude names changed on that same day"
+  end
+
+  test "api-at-before: includes a name changed on an earlier day" do
+    ids = search_ids("api-at-before: 28-07-2026")
+    assert_includes ids, names(:the_regnum).id,
+                    "Expected the 27th to be before the 28th"
+    refute_includes ids, names(:a_family).id,
+                     "Expected the 15th of August to be excluded"
+  end
+
+  test "api-at-after: and api-at-before: combine into a date range" do
+    ids = search_ids("api-at-after: 26-07-2026 api-at-before: 28-07-2026")
+    assert_includes ids, names(:the_regnum).id,
+                    "Expected the 27th to fall inside the range"
+    refute_includes ids, names(:a_family).id,
+                     "Expected the 15th of August to fall outside the range"
+  end
+end

--- a/test/models/search/on_name/api_name/simple_test.rb
+++ b/test/models/search/on_name/api_name/simple_test.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+require "test_helper"
+load "test/models/search/users.rb"
+load "test/models/search/on_name/test_helper.rb"
+
+class SearchOnNameApiNameSimpleTest < ActiveSupport::TestCase
+  # There are more name fixtures than the default result limit, so searches
+  # that match most of them need an explicit limit to be deterministic.
+  ALL = "limit: 500"
+
+  setup do
+    names(:the_regnum).update_columns(api_name: "JIRA-Sync")
+    names(:a_family).update_columns(api_name: "batch-loader")
+    names(:a_species).update_columns(api_name: nil)
+  end
+
+  def search_ids(query_string)
+    params = ActiveSupport::HashWithIndifferentAccess.new(
+      query_target: "name",
+      query_string: query_string,
+      current_user: build_edit_user
+    )
+    search = Search::Base.new(params)
+    confirm_results_class(search.executed_query.results)
+    search.executed_query.results.collect(&:id)
+  end
+
+  test "api-name: matches the name changed by that api" do
+    assert_includes search_ids("api-name: jira-sync"),
+                    names(:the_regnum).id,
+                    "Expected the name changed by jira-sync in the results"
+  end
+
+  test "api-name: excludes a name changed by another api" do
+    refute_includes search_ids("api-name: jira-sync"),
+                    names(:a_family).id,
+                    "Expected the name changed by batch-loader to be excluded"
+  end
+
+  test "api-name: ignores case" do
+    assert_includes search_ids("api-name: JIRA-SYNC"),
+                    names(:the_regnum).id,
+                    "Expected the search to be case insensitive"
+  end
+
+  test "api-name: adds wildcards at both ends" do
+    assert_includes search_ids("api-name: sync"),
+                    names(:the_regnum).id,
+                    "Expected a partial search term to match"
+    assert_includes search_ids("api-name: loader"),
+                    names(:a_family).id,
+                    "Expected a partial search term to match"
+  end
+
+  test "api-name: excludes a name never changed by an api" do
+    refute_includes search_ids("api-name: sync"),
+                    names(:a_species).id,
+                    "Expected a name with no api_name to be excluded"
+  end
+
+  test "has-api-name: includes a name changed by an api" do
+    ids = search_ids("has-api-name: #{ALL}")
+    assert_includes ids, names(:the_regnum).id,
+                    "Expected the name changed by jira-sync in the results"
+    assert_includes ids, names(:a_family).id,
+                    "Expected the name changed by batch-loader in the results"
+  end
+
+  test "has-api-name: excludes a name never changed by an api" do
+    refute_includes search_ids("has-api-name: #{ALL}"),
+                    names(:a_species).id,
+                    "Expected a name with no api_name to be excluded"
+  end
+
+  test "has-no-api-name: includes a name never changed by an api" do
+    assert_includes search_ids("has-no-api-name: #{ALL}"),
+                    names(:a_species).id,
+                    "Expected a name with no api_name in the results"
+  end
+
+  test "has-no-api-name: excludes a name changed by an api" do
+    refute_includes search_ids("has-no-api-name: #{ALL}"),
+                    names(:the_regnum).id,
+                    "Expected the name changed by jira-sync to be excluded"
+  end
+
+  test "the two directives return disjoint result sets" do
+    with_api_name = search_ids("has-api-name: #{ALL}")
+    without_api_name = search_ids("has-no-api-name: #{ALL}")
+    assert_empty with_api_name & without_api_name,
+                 "A name cannot both have and not have an api name"
+  end
+end


### PR DESCRIPTION
## Description
Add `api-name`, `api-at`, `api-at-after`, `api-at-before`, `has-api-name`, `has-no-api-name` directives for name query

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [ ] Bumped version
- [ ] Updated changelog (Please add an entry to the changelog for the current year)
