### PR TITLE
NSL-3228: Name Delete: Add a 2 second delay before checking Name is deleted, also make the error message more neutral

### DIFF
--- a/app/controllers/names_deletes_controller.rb
+++ b/app/controllers/names_deletes_controller.rb
@@ -24,7 +24,7 @@ class NamesDeletesController < ApplicationController
     raise "Not confirmed" unless @names_delete.save! # i.e. confirmed
 
     delete_via_service(names_delete_params)
-    raise "Name not deleted" unless name_is_gone?
+    raise "Name delete was requested but not confirmed" unless name_is_gone?
     render partial: "ok"
   rescue StandardError => e
     logger.error("Exception deleting name: #{e}")
@@ -45,6 +45,7 @@ class NamesDeletesController < ApplicationController
   # Services response on failure may not reliably give a clue that the delete
   # failed, so we have to check.
   def name_is_gone?
+    sleep(2)
     !Name.exists?(names_delete_params[:name_id])
   end
 

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 27-July-2026
+  :jira_id: '3228'
+  :description: |-
+    Name Delete: Add a 2 second delay before checking Name is deleted, also make the error message more neutral
 - :date: 24-July-2026
   :jira_id: '5464'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.63
+appversion=5.1.4.64

--- a/test/controllers/names_deletes/confirm/for_editor/renders_error_when_service_lies_about_success_test.rb
+++ b/test/controllers/names_deletes/confirm/for_editor/renders_error_when_service_lies_about_success_test.rb
@@ -63,7 +63,7 @@ class NamesDeleteConfirmForEditorRendersErrorWhenServiceLiesAboutSuccessTest < A
                       user_full_name: "Fred Jones",
                       groups: ["edit"] })
     assert_response :success
-    assert_includes @response.body, "Name not deleted"
+    assert_includes @response.body, "Name delete was requested but not confirmed"
     assert_not_includes @response.body, "Record deleted"
     assert Name.exists?(@name.id), "Name should still exist - the service did not really delete it"
   end


### PR DESCRIPTION
## Description
Minor refinement - see JIra.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
Delete some Names, with long reasons - see Jira.

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
