### PR TITLE
NSL-5461: Synonym typeahead sorting: when a Reference has no iso_publ…ication_date, use its parent's iso_publication_date

### DIFF
--- a/app/models/instance/as_typeahead/for_synonymy.rb
+++ b/app/models/instance/as_typeahead/for_synonymy.rb
@@ -43,6 +43,14 @@ class Instance::AsTypeahead::ForSynonymy
             "instance_type.name as instance_type_name"
   SEARCH_LIMIT = 50
 
+  # ref_parent_date(ref_id) is an existing db function (see db/structure.sql)
+  # that returns the reference's own iso_publication_date, unless its ref_type
+  # has use_parent_details set, in which case it falls back to the parent
+  # reference's iso_publication_date. Re-using it here keeps this ordering
+  # consistent with how the rest of the app treats parent/child reference
+  # dates, rather than reimplementing the same rule.
+  ISO_PUBLICATION_DATE_ORDER = "coalesce(ref_parent_date(reference.id), '0000-00-00')"
+
   def initialize(terms, name_id)
     @results = []
     @name_binds = []
@@ -68,7 +76,8 @@ class Instance::AsTypeahead::ForSynonymy
                     .joins(:instance_type)
                     .where("cited_by_id is null")
                     .where("name_id != ?", name_id.to_i)
-                    .order(Arel.sql("name_rank.sort_order,lower(f_unaccent(full_name)), iso_publication_date"))
+                    .order(Arel.sql("name_rank.sort_order,lower(f_unaccent(full_name)), " \
+                                    "#{ISO_PUBLICATION_DATE_ORDER}"))
                     .limit(SEARCH_LIMIT)
     restrict_ranks(query, name_id)
   end
@@ -114,7 +123,7 @@ class Instance::AsTypeahead::ForSynonymy
     reference_year = match.to_s 
     if reference_year.present? &&
        reference_year.to_i > 1000 && reference_year.to_i < 3000
-      reference_binds.push(" iso_publication_date like ? ||'%' ")
+      reference_binds.push(" reference.iso_publication_date like ? ||'%' ")
       reference_binds.push(reference_year)
     end
     reference_binds

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 27-July-2026
+  :jira_id: '5461'
+  :description: |-
+    Synonym typeahead sorting: when a Reference has no <code>iso_publication_date</code>, use its parent's <code>iso_publication_date</code> if appropriate
+- :date: 27-July-2026
   :jira_id: '5860'
   :description: |-
     Query directives for api_name and api_at in name search

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.65
+appversion=5.1.4.66

--- a/test/fixtures/instances.yml
+++ b/test/fixtures/instances.yml
@@ -947,3 +947,51 @@ a_soft_deleted_instance:
   page: exclude-from-ordering-test
   deleted_at: <%= Time.now %>
 
+# Standalone instances of the same name, used to test that
+# Instance::AsTypeahead::ForSynonymy orders a reference with no
+# iso_publication_date of its own by its parent reference's date -
+# but only when the reference's ref_type has use_parent_details set
+# (see db function ref_parent_date() and ref_types.yml
+# chapter_using_parent_details).
+#
+# page is "exclude-from-ordering-test" on all four (the established
+# convention in this file) so they're excluded from
+# OrderByPage#test_approximates_numeric_sorting, which otherwise scans
+# every instance's page value. The test instead tells these four apart
+# by each reference's distinct citation text.
+fallback_earlier_instance:
+  <<: *DEFAULTS
+  reference: fallback_earlier_reference
+  name: fallback_reference_date_name
+  instance_type: comb_nov
+  verbatim_name_string: fallback-earlier
+  page: exclude-from-ordering-test
+
+fallback_child_instance_using_parent_date:
+  <<: *DEFAULTS
+  reference: fallback_child_reference_no_own_date
+  name: fallback_reference_date_name
+  instance_type: comb_nov
+  verbatim_name_string: fallback-child-no-own-date
+  page: exclude-from-ordering-test
+
+fallback_later_instance:
+  <<: *DEFAULTS
+  reference: fallback_later_reference
+  name: fallback_reference_date_name
+  instance_type: comb_nov
+  verbatim_name_string: fallback-later
+  page: exclude-from-ordering-test
+
+# Control: same "no own date" situation as the fixture above, but its
+# ref_type (plain `chapter`) does NOT have use_parent_details set, so it
+# should NOT inherit the parent's 1850 date - it should sort as if it had
+# no date at all (i.e. before fallback_earlier_instance's 1700).
+fallback_ungated_child_instance:
+  <<: *DEFAULTS
+  reference: fallback_ungated_child_reference_no_own_date
+  name: fallback_reference_date_name
+  instance_type: comb_nov
+  verbatim_name_string: fallback-ungated-child-no-own-date
+  page: exclude-from-ordering-test
+

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -2718,4 +2718,29 @@ a_soft_deleted_name:
   uri: soft_deleted_name_1
   deleted_at: 2020-01-01 00:00:00
 
+# Name shared by four standalone instances used to test that
+# Instance::AsTypeahead::ForSynonymy orders a reference with no
+# iso_publication_date of its own using its parent reference's date.
+#
+# Deliberately ranked "classis" (like the a_classis fixture) with no
+# parent/family, rather than "species": a species-ranked name matching a
+# broad wildcard search (e.g. "*") gets pulled into the infraspecific-band
+# rank-restriction tests elsewhere and can push their expected rare-rank
+# results past the typeahead's 50-result limit. Ranks above family aren't
+# covered by any of those broad wildcard searches. Also has no `parent`,
+# so it doesn't perturb tests that count a_genus's children.
+fallback_reference_date_name:
+  <<: *DEFAULTS
+  name_element: fallbackia
+  simple_name: 'Fallbackia parentdatensis'
+  full_name: 'Fallbackia parentdatensis'
+  name_rank: classis
+  name_status: legitimate
+  name_type: scientific
+  namespace: apni
+  parent_id: nil
+  family_id: nil
+  name_path: 'Plantae/Fallbackia parentdatensis'
+  uri: fallback_reference_date_name
+
 

--- a/test/fixtures/ref_types.yml
+++ b/test/fixtures/ref_types.yml
@@ -75,9 +75,19 @@ unknown:
   parent_optional: true
   parent: unknown
 
-part: 
-  name: Part 
+part:
+  name: Part
   parent_optional: false
   parent: paper
+
+# Used to test ref_parent_date()/Instance::AsTypeahead::ForSynonymy's
+# fallback to a parent reference's iso_publication_date. Deliberately
+# separate from `chapter` above (which has use_parent_details: false)
+# so that fixture isn't changed for other tests relying on it.
+chapter_using_parent_details:
+  name: Chapter (uses parent details)
+  parent: book
+  parent_optional: false
+  use_parent_details: true
 
 

--- a/test/fixtures/references.yml
+++ b/test/fixtures/references.yml
@@ -1942,3 +1942,61 @@ chah_2025:
   author: chah
   ref_author_role: author
   ref_type: section
+
+# Fixtures for Instance::AsTypeahead::ForSynonymy sort-order fallback:
+# a reference with no iso_publication_date of its own should sort as if
+# it had its parent reference's iso_publication_date.
+fallback_parent_reference:
+  <<: *DEFAULTS
+  title: "Fallback Parent Reference"
+  citation: "Fallback Parent Reference"
+  citation_html: "Fallback Parent Reference"
+  display_title: "Fallback Parent Reference"
+  author: unknown
+  ref_author_role: dash
+  ref_type: book
+  iso_publication_date: 1850
+
+fallback_child_reference_no_own_date:
+  <<: *DEFAULTS
+  title: "Fallback Child Reference With No Own Date"
+  citation: "Fallback Child Reference With No Own Date"
+  citation_html: "Fallback Child Reference With No Own Date"
+  display_title: "Fallback Child Reference With No Own Date"
+  author: unknown
+  ref_author_role: dash
+  ref_type: chapter_using_parent_details
+  parent: fallback_parent_reference
+
+fallback_ungated_child_reference_no_own_date:
+  <<: *DEFAULTS
+  title: "Fallback Ungated Child Reference With No Own Date"
+  citation: "Fallback Ungated Child Reference With No Own Date"
+  citation_html: "Fallback Ungated Child Reference With No Own Date"
+  display_title: "Fallback Ungated Child Reference With No Own Date"
+  author: unknown
+  ref_author_role: dash
+  ref_type: chapter
+  parent: fallback_parent_reference
+
+fallback_earlier_reference:
+  <<: *DEFAULTS
+  title: "Fallback Earlier Reference"
+  citation: "Fallback Earlier Reference"
+  citation_html: "Fallback Earlier Reference"
+  display_title: "Fallback Earlier Reference"
+  author: unknown
+  ref_author_role: dash
+  ref_type: book
+  iso_publication_date: 1700
+
+fallback_later_reference:
+  <<: *DEFAULTS
+  title: "Fallback Later Reference"
+  citation: "Fallback Later Reference"
+  citation_html: "Fallback Later Reference"
+  display_title: "Fallback Later Reference"
+  author: unknown
+  ref_author_role: dash
+  ref_type: book
+  iso_publication_date: 1980

--- a/test/models/instance/as_typeahead/for_synonymy/reference_parent_date_fallback_test.rb
+++ b/test/models/instance/as_typeahead/for_synonymy/reference_parent_date_fallback_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# When a reference has no iso_publication_date of its own, results should
+# sort as if it had its parent reference's iso_publication_date - but only
+# when the reference's ref_type has use_parent_details set. This mirrors
+# the existing db function ref_parent_date() (see db/structure.sql), which
+# Instance::AsTypeahead::ForSynonymy's ordering now reuses.
+#
+# The search below is run against names(:a_classis) - an above-family rank
+# that restrict_ranks doesn't filter at all - purely so this test doesn't
+# depend on rank restriction behaviour. fallback_reference_date_name (the
+# shared name of all four fixture instances) is itself ranked "classis"
+# for the same reason: it keeps these fixtures out of the broad "*"
+# wildcard searches used by the infraspecific/infrafamilial rank-
+# restriction tests elsewhere, which are sensitive to the exact set of
+# results returned within Instance::AsTypeahead::ForSynonymy::SEARCH_LIMIT.
+class ForSynonymyReferenceParentDateFallbackTest < ActiveSupport::TestCase
+  def search
+    Instance::AsTypeahead::ForSynonymy.new("Fallbackia parentdatensis",
+                                           names(:a_classis).id)
+  end
+
+  def value_index(values, marker)
+    values.index { |v| v.include?(marker) }
+  end
+
+  test "all four fixture instances are found" do
+    values = search.results.collect { |r| r[:value] }
+
+    assert value_index(values, "Fallback Ungated Child Reference With No Own Date"),
+           "Should include the ungated no-date instance."
+    assert value_index(values, "Fallback Earlier Reference"),
+           "Should include the 1700 instance."
+    assert value_index(values, "Fallback Child Reference With No Own Date"),
+           "Should include the instance whose reference has no own date."
+    assert value_index(values, "Fallback Later Reference"),
+           "Should include the 1980 instance."
+  end
+
+  test "a reference with no own date sorts by its parent reference's date " \
+       "when its ref_type uses parent details" do
+    values = search.results.collect { |r| r[:value] }
+
+    earlier_index = value_index(values, "Fallback Earlier Reference")
+    fallback_index = value_index(values, "Fallback Child Reference With No Own Date")
+    later_index = value_index(values, "Fallback Later Reference")
+
+    assert earlier_index < fallback_index,
+           "The 1700 instance should sort before the instance falling " \
+           "back to its parent's 1850 date."
+    assert fallback_index < later_index,
+           "The instance falling back to its parent's 1850 date should " \
+           "sort before the 1980 instance."
+  end
+
+  test "a reference with no own date does NOT borrow its parent's date " \
+       "when its ref_type does not use parent details" do
+    values = search.results.collect { |r| r[:value] }
+
+    ungated_index = value_index(values, "Fallback Ungated Child Reference With No Own Date")
+    earlier_index = value_index(values, "Fallback Earlier Reference")
+
+    assert ungated_index < earlier_index,
+           "A reference with no date, and a ref_type that does not use " \
+           "parent details, should sort as if it had no date at all - " \
+           "i.e. before the 1700 instance, not alongside the 1850 parent."
+  end
+
+  test "the instance's own citation, not the parent's, is displayed" do
+    value = search.results
+                  .collect { |r| r[:value] }
+                  .find { |v| v.include?("Fallback Child Reference With No Own Date") }
+
+    assert value.present?, "Should include the fallback child instance."
+    assert_includes value, "Fallback Child Reference With No Own Date",
+                     "Should display the reference's own citation."
+    refute_includes value, "Fallback Parent Reference",
+                     "Should not display the parent reference's citation " \
+                     "- the fallback only affects sort order."
+  end
+end


### PR DESCRIPTION
## Description
Used database function to use the parent's information if appropriate.  See Jira for more details.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
See case described in Jira

## Tests
- [x] Unit tests - Claude
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
