### PR TITLE
NSL-5860 - Add activity queries for API name and API at filters

### DIFF
--- a/app/models/search/on_instance/field_rule.rb
+++ b/app/models/search/on_instance/field_rule.rb
@@ -102,6 +102,15 @@ from comment where comment.instance_id = instance.id)",
                                  and lower(instance_note_key.name) = 'type')) ",
                                leading_wildcard: true,
                                trailing_wildcard: true },
+    "api-name:" => { where_clause: " lower(api_name) like ? ",
+                     trailing_wildcard: true,
+                     leading_wildcard: true },
+    "api-at:" => { where_clause: " to_char(api_at at time zone 'Australia/Melbourne', 'dd-mm-yyyy') like ? ",
+                   trailing_wildcard: true,
+                   leading_wildcard: true },
+    "api-at-after:" => { where_clause: " (api_at at time zone 'Australia/Melbourne') >= to_date(?, 'dd-mm-yyyy')
+                                  + interval '1 day' " },
+    "api-at-before:" => { where_clause: " (api_at at time zone 'Australia/Melbourne') < to_date(?, 'dd-mm-yyyy') " },
     "apc-dist-note-matches:" => { where_clause: " exists (select null
                                  from instance_note
                                  where instance_id = instance.id
@@ -206,6 +215,8 @@ from comment where comment.instance_id = instance.id)",
                             takes_no_arg: true},
     "is-not-soft-deleted:" => { where_clause: " deleted_at is null",
                                 takes_no_arg: true},
+    "has-api-name:" => { where_clause: " api_name is not null" },
+    "has-no-api-name:" => { where_clause: " api_name is null" },
     "verbatim-name-exact:" => { where_clause:
                                  "lower(verbatim_name_string) like lower(?) " },
     "verbatim-name:" => { where_clause:

--- a/app/models/search/on_instance/field_rule.rb
+++ b/app/models/search/on_instance/field_rule.rb
@@ -215,8 +215,8 @@ from comment where comment.instance_id = instance.id)",
                             takes_no_arg: true},
     "is-not-soft-deleted:" => { where_clause: " deleted_at is null",
                                 takes_no_arg: true},
-    "has-api-name:" => { where_clause: " api_name is not null" },
-    "has-no-api-name:" => { where_clause: " api_name is null" },
+    "has-api-name:" => { where_clause: " api_name is not null", takes_no_arg: true },
+    "has-no-api-name:" => { where_clause: " api_name is null", takes_no_arg: true },
     "verbatim-name-exact:" => { where_clause:
                                  "lower(verbatim_name_string) like lower(?) " },
     "verbatim-name:" => { where_clause:

--- a/app/views/instances/advanced_search/_examples.html.erb
+++ b/app/views/instances/advanced_search/_examples.html.erb
@@ -254,6 +254,54 @@
 </table>
 <br>
 
+<h5 class="">API change searches</h5>
+<table class="example-searches table table-striped">
+  <% [
+      {search_target: 'Instances',
+       search_string: "has-api-name:",
+       explanation: %Q(Instances that have been changed by an API.)},
+      {search_target: 'Instances',
+       search_string: "has-no-api-name:",
+       explanation: %Q(Instances that have never been changed by an API.)},
+      {search_target: 'Instances',
+       search_string: "api-name: jira-sync",
+       explanation: %Q(Instances last changed by an API whose name contains "jira-sync".  Case-insensitive, with wildcards added at both ends.)},
+      {search_target: 'Instances',
+       search_string: "api-at: 27-07-2026",
+       explanation: %Q(Instances changed by an API on 27 July 2026.)},
+      {search_target: 'Instances',
+       search_string: "api-at: 07-2026",
+       explanation: %Q(Instances changed by an API in July 2026 - the date is matched with wildcards at both ends.)},
+      {search_target: 'Instances',
+       search_string: "api-at: 2026",
+       explanation: %Q(Instances changed by an API in 2026.)},
+      {search_target: 'Instances',
+       search_string: "api-at-after: 26-07-2026",
+       explanation: %Q(Instances changed by an API after 26 July 2026, excluding the 26th itself.)},
+      {search_target: 'Instances',
+       search_string: "api-at-before: 28-07-2026",
+       explanation: %Q(Instances changed by an API before 28 July 2026, excluding the 28th itself.)},
+      {search_target: 'Instances',
+       search_string: "api-at-after: 26-07-2026 api-at-before: 28-07-2026",
+       explanation: %Q(Instances changed by an API within a date range - here, 27 July 2026 only.)},
+      {search_target: 'Instances',
+       search_string: "api-name: jira-sync api-at-after: 30-06-2026",
+       explanation: %Q(Instances changed by the "jira-sync" API after 30 June 2026.)},
+      ].each do |val| %>
+  <tr>
+    <td class="width-30-percent">
+      <a href="javascript:void(0)"
+         class="example-search width-100-percent"
+         title="Link to search">
+         <span class="blue"><%= link_to(val[:search_string], search_path(query_string: val[:search_string], query_target: val[:search_target]),class:'blue', title: "Run the described search.") %></span>
+      </a>
+    </td>
+    <td><%= val[:explanation].html_safe %></td>
+  </tr>
+  <% end %>
+</table>
+<br>
+
 <h5 class="">Count instances</h5>
 <table class="example-searches table table-striped">
   <% [{search_target: 'Instances', search_string: "count",explanation: %Q(Start with "count instance" to count instances.)},
@@ -269,6 +317,12 @@
       {search_target: 'Instances',
        search_string: "count is-tax-nov-for-orth-var-name:",
        explanation: %Q(Count tax. nov. instances with an orth-var name.)},
+      {search_target: 'Instances',
+       search_string: "count has-api-name:",
+       explanation: %Q(Count instances that have been changed by an API.)},
+      {search_target: 'Instances',
+       search_string: "count api-at: 2026",
+       explanation: %Q(Count instances changed by an API in 2026.)},
       ].each do |val| %>
   <tr>
     <td class="width-30-percent">

--- a/app/views/instances/advanced_search/_field_help.html.erb
+++ b/app/views/instances/advanced_search/_field_help.html.erb
@@ -288,6 +288,40 @@ word "darwin" followed by a space, one or more other characters followed by "bar
   <% end %>
 </table>
 
+<h4>API changes</h4>
+<p>Instances changed via the API record the name of the API that changed them and when it happened.</p>
+<p>Dates are entered as <code>dd-mm-yyyy</code> in Australia/Melbourne time.</p>
+<table class="table table-striped">
+  <tr>
+    <th>Field</th>
+    <th>Description</th>
+  </tr>
+  <% [
+         {field_name: 'api-name:', description: "Name of the API that last changed the instance.  Case-insensitive, with wildcards added at both ends."},
+         {field_name: 'has-api-name:', description: "Instance has been changed by an API.  Takes no argument."},
+         {field_name: 'has-no-api-name:', description: "Instance has never been changed by an API.  Takes no argument."},
+         {field_name: 'api-at:', description: %Q(Date the API last changed the instance, as <code>dd-mm-yyyy</code>.  Wildcards are added at both ends, so <code>07-2026</code> matches a month and <code>2026</code> matches a year.)},
+         {field_name: 'api-at-after:', description: "Changed by an API after the given date, excluding the date itself."},
+         {field_name: 'api-at-before:', description: "Changed by an API before the given date, excluding the date itself -- tip: combine with api-at-after: for a date range."},
+     ].each do |val| %>
+    <tr>
+      <td class="width-20-percent">
+        <a href="javascript:void(0)" class="searchable-field width-100-percent"
+           data-search-directive="<%= val[:field_name] %>"
+           title='Add "<%= val[:field_name] %>" field to search.'>
+          <span class="blue"><%= val[:field_name] %></span>
+        </a>
+      </td>
+      <td><%= val[:description].html_safe %></td>
+      <% if val[:partial].present? %>
+        <td><%= render partial: val[:partial] %></td>
+      <% else %>
+        <td></td>
+      <% end %>
+    </tr>
+  <% end %>
+</table>
+
 <h4>Reference fields</h4>
 <table class="table table-striped">
   <tr>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 29-July-2026
+  :jira_id: '5860'
+  :description: |-
+    Query directives for api_name and api_at in instance search
 - :date: 28-July-2026
   :jira_id: '5855'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.67
+appversion=5.1.4.68

--- a/test/models/search/on_instance/api_at/simple_test.rb
+++ b/test/models/search/on_instance/api_at/simple_test.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+
+# Search model tests for the api-at: / api-at-after: / api-at-before:
+# instance search directives.
+class SearchOnInstanceApiAtSimpleTest < ActiveSupport::TestCase
+  DISPLAY_ZONE = "Australia/Melbourne"
+
+  setup do
+    Time.use_zone(DISPLAY_ZONE) do
+      instances(:gaertner_created_metrosideros_costata)
+        .update_columns(api_at: Time.zone.parse("2026-07-27 09:00"))
+      instances(:britten_created_angophora_costata)
+        .update_columns(api_at: Time.zone.parse("2026-08-15 12:00"))
+      instances(:triodia_in_brassard).update_columns(api_at: nil)
+    end
+  end
+
+  def search_ids(query_string)
+    params = ActiveSupport::HashWithIndifferentAccess.new(
+      query_target: "instance",
+      query_string: query_string,
+      current_user: build_edit_user
+    )
+    search = Search::Base.new(params)
+    search.executed_query.results.collect(&:id)
+  end
+
+  test "api-at: matches an instance changed on that date" do
+    assert_includes search_ids("api-at: 27-07-2026"),
+                    instances(:gaertner_created_metrosideros_costata).id,
+                    "Expected the instance changed on 27-07-2026 in the results"
+  end
+
+  test "api-at: excludes an instance changed on another date" do
+    refute_includes search_ids("api-at: 27-07-2026"),
+                    instances(:britten_created_angophora_costata).id,
+                    "Expected the instance changed on 15-08-2026 to be excluded"
+  end
+
+  test "api-at: uses the display timezone, not UTC" do
+    refute_includes search_ids("api-at: 26-07-2026"),
+                    instances(:gaertner_created_metrosideros_costata).id,
+                    "9am on the 27th in #{DISPLAY_ZONE} must not match the 26th"
+  end
+
+  test "api-at: matches on month and year alone" do
+    assert_includes search_ids("api-at: 07-2026"),
+                    instances(:gaertner_created_metrosideros_costata).id,
+                    "Expected a month-and-year search to match"
+    refute_includes search_ids("api-at: 07-2026"),
+                    instances(:britten_created_angophora_costata).id,
+                    "Expected an instance changed in August to be excluded"
+  end
+
+  test "api-at: matches on year alone" do
+    ids = search_ids("api-at: 2026")
+    assert_includes ids, instances(:gaertner_created_metrosideros_costata).id,
+                    "Expected a year search to match the July instance"
+    assert_includes ids, instances(:britten_created_angophora_costata).id,
+                    "Expected a year search to match the August instance"
+  end
+
+  test "api-at: excludes instances that have never been changed by the api" do
+    refute_includes search_ids("api-at: 2026"),
+                    instances(:triodia_in_brassard).id,
+                    "Expected an instance with no api_at to be excluded"
+  end
+
+  test "api-at-after: excludes the named day itself" do
+    refute_includes search_ids("api-at-after: 27-07-2026"),
+                    instances(:gaertner_created_metrosideros_costata).id,
+                    "Expected after: to exclude instances changed on that same day"
+  end
+
+  test "api-at-after: includes an instance changed on a later day" do
+    ids = search_ids("api-at-after: 26-07-2026")
+    assert_includes ids, instances(:gaertner_created_metrosideros_costata).id,
+                    "Expected the 27th to be after the 26th"
+    assert_includes ids, instances(:britten_created_angophora_costata).id,
+                    "Expected the 15th of August to be after the 26th of July"
+  end
+
+  test "api-at-before: excludes the named day itself" do
+    refute_includes search_ids("api-at-before: 27-07-2026"),
+                    instances(:gaertner_created_metrosideros_costata).id,
+                    "Expected before: to exclude instances changed on that same day"
+  end
+
+  test "api-at-before: includes an instance changed on an earlier day" do
+    ids = search_ids("api-at-before: 28-07-2026")
+    assert_includes ids, instances(:gaertner_created_metrosideros_costata).id,
+                    "Expected the 27th to be before the 28th"
+    refute_includes ids, instances(:britten_created_angophora_costata).id,
+                    "Expected the 15th of August to be excluded"
+  end
+
+  test "api-at-after: and api-at-before: combine into a date range" do
+    ids = search_ids("api-at-after: 26-07-2026 api-at-before: 28-07-2026")
+    assert_includes ids, instances(:gaertner_created_metrosideros_costata).id,
+                    "Expected the 27th to fall inside the range"
+    refute_includes ids, instances(:britten_created_angophora_costata).id,
+                    "Expected the 15th of August to fall outside the range"
+  end
+end

--- a/test/models/search/on_instance/api_name/simple_test.rb
+++ b/test/models/search/on_instance/api_name/simple_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+
+# Search model tests for the api-name: / has-api-name: / has-no-api-name:
+# instance search directives.
+class SearchOnInstanceApiNameSimpleTest < ActiveSupport::TestCase
+  # There are more instance fixtures than the default result limit is
+  # guaranteed to hold, so searches that match most of them need an explicit
+  # limit to be deterministic.
+  ALL = "limit: 500"
+
+  setup do
+    instances(:gaertner_created_metrosideros_costata)
+      .update_columns(api_name: "JIRA-Sync")
+    instances(:britten_created_angophora_costata)
+      .update_columns(api_name: "batch-loader")
+    instances(:triodia_in_brassard).update_columns(api_name: nil)
+  end
+
+  def search_ids(query_string)
+    params = ActiveSupport::HashWithIndifferentAccess.new(
+      query_target: "instance",
+      query_string: query_string,
+      current_user: build_edit_user
+    )
+    search = Search::Base.new(params)
+    search.executed_query.results.collect(&:id)
+  end
+
+  test "api-name: matches the instance changed by that api" do
+    assert_includes search_ids("api-name: jira-sync"),
+                    instances(:gaertner_created_metrosideros_costata).id,
+                    "Expected the instance changed by jira-sync in the results"
+  end
+
+  test "api-name: excludes an instance changed by another api" do
+    refute_includes search_ids("api-name: jira-sync"),
+                    instances(:britten_created_angophora_costata).id,
+                    "Expected the instance changed by batch-loader to be excluded"
+  end
+
+  test "api-name: ignores case" do
+    assert_includes search_ids("api-name: JIRA-SYNC"),
+                    instances(:gaertner_created_metrosideros_costata).id,
+                    "Expected the search to be case insensitive"
+  end
+
+  test "api-name: adds wildcards at both ends" do
+    assert_includes search_ids("api-name: sync"),
+                    instances(:gaertner_created_metrosideros_costata).id,
+                    "Expected a partial search term to match"
+    assert_includes search_ids("api-name: loader"),
+                    instances(:britten_created_angophora_costata).id,
+                    "Expected a partial search term to match"
+  end
+
+  test "api-name: excludes an instance never changed by an api" do
+    refute_includes search_ids("api-name: sync"),
+                    instances(:triodia_in_brassard).id,
+                    "Expected an instance with no api_name to be excluded"
+  end
+
+  test "has-api-name: includes an instance changed by an api" do
+    ids = search_ids("has-api-name: #{ALL}")
+    assert_includes ids, instances(:gaertner_created_metrosideros_costata).id,
+                    "Expected the instance changed by jira-sync in the results"
+    assert_includes ids, instances(:britten_created_angophora_costata).id,
+                    "Expected the instance changed by batch-loader in the results"
+  end
+
+  test "has-api-name: excludes an instance never changed by an api" do
+    refute_includes search_ids("has-api-name: #{ALL}"),
+                    instances(:triodia_in_brassard).id,
+                    "Expected an instance with no api_name to be excluded"
+  end
+
+  test "has-no-api-name: includes an instance never changed by an api" do
+    assert_includes search_ids("has-no-api-name: #{ALL}"),
+                    instances(:triodia_in_brassard).id,
+                    "Expected an instance with no api_name in the results"
+  end
+
+  test "has-no-api-name: excludes an instance changed by an api" do
+    refute_includes search_ids("has-no-api-name: #{ALL}"),
+                    instances(:gaertner_created_metrosideros_costata).id,
+                    "Expected the instance changed by jira-sync to be excluded"
+  end
+
+  test "the two directives return disjoint result sets" do
+    with_api_name = search_ids("has-api-name: #{ALL}")
+    without_api_name = search_ids("has-no-api-name: #{ALL}")
+    assert_empty with_api_name & without_api_name,
+                 "An instance cannot both have and not have an api name"
+  end
+end


### PR DESCRIPTION
## Description
Implement api_name and api_at query directives for instance search

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
