### PR TITLE
Add API name and date filters to search directives and examples

### DIFF
--- a/app/models/search/on_reference/field_rule.rb
+++ b/app/models/search/on_reference/field_rule.rb
@@ -19,12 +19,23 @@
 # Field rules available for building predicates.
 class Search::OnReference::FieldRule
   RULES = {
+    "api-name:" => { where_clause: " lower(api_name) like ? ",
+                     trailing_wildcard: true,
+                     leading_wildcard: true },
+    "api-at:" => { where_clause: " to_char(api_at at time zone 'Australia/Melbourne', 'dd-mm-yyyy') like ? ",
+                   trailing_wildcard: true,
+                   leading_wildcard: true },
+    "api-at-after:"         => { where_clause: " (api_at at time zone 'Australia/Melbourne') >= to_date(?, 'dd-mm-yyyy')
+                                  + interval '1 day' " },
+    "api-at-before:"        => { where_clause: " (api_at at time zone 'Australia/Melbourne') < to_date(?, 'dd-mm-yyyy') " },
     "is-a-duplicate:"       => { where_clause: " duplicate_of_id is not null" },
     "is-not-a-duplicate:"   => { where_clause: " duplicate_of_id is null" },
     "is-a-parent:"          => { where_clause: " exists (select null from
 reference child where child.parent_id = reference.id) " },
     "is-not-a-parent:"      => { where_clause: " not exists (select null from
 reference child where child.parent_id = reference.id) " },
+    "has-api-name:"         => { where_clause: " api_name is not null", takes_no_arg: true },
+    "has-no-api-name:"      => { where_clause: " api_name is null", takes_no_arg: true},
     "has-no-children:"      => { where_clause: " not exists (select null from
 reference child where child.parent_id = reference.id) " },
     "has-no-parent:"        => { where_clause: " parent_id is null" },

--- a/app/models/search/reference/field_rule.rb
+++ b/app/models/search/reference/field_rule.rb
@@ -19,6 +19,17 @@
 # Field rules available for building predicates.
 class Search::Reference::FieldRule
   RULES = {
+    "api-name:" => { where_clause: " lower(api_name) like ? ",
+                     trailing_wildcard: true,
+                     leading_wildcard: true },
+    "api-at:" => { where_clause: " to_char(api_at at time zone 'Australia/Melbourne', 'dd-mm-yyyy') like ? ",
+                   trailing_wildcard: true,
+                   leading_wildcard: true },
+    "api-at-after:" => { where_clause: " (api_at at time zone 'Australia/Melbourne') >= to_date(?, 'dd-mm-yyyy')
+                                  + interval '1 day' " },
+    "api-at-before:" => { where_clause: " (api_at at time zone 'Australia/Melbourne') < to_date(?, 'dd-mm-yyyy') " },
+    "has-api-name:" => { where_clause: " api_name is not null", takes_no_arg: true },
+    "has-no-api-name:" => { where_clause: " api_name is null", takes_no_arg: true},
     "is-a-duplicate:" => { where_clause: " duplicate_of_id is not null",
                            takes_no_arg: true},
     "is-not-a-duplicate:" => { where_clause: " duplicate_of_id is null",

--- a/app/views/references/advanced_search/_directives_list.erb
+++ b/app/views/references/advanced_search/_directives_list.erb
@@ -253,6 +253,32 @@ in the following formats:</p>
 </table>
 <br>
 
+<h5>API changes</h5>
+<p>References changed via the API record the name of the API that changed them and when it happened.</p>
+<p>Dates are entered as <code>dd-mm-yyyy</code> in Australia/Melbourne time.</p>
+<table class="table table-striped">
+  <% [
+      {field_name: 'api-name:', description: "name of the API that last changed the reference, case-insensitive, wildcards added at both ends"},
+      {field_name: 'has-api-name:', description: "reference has been changed by an API; no arguments"},
+      {field_name: 'has-no-api-name:', description: "reference has never been changed by an API; no arguments"},
+      {field_name: 'api-at:', description: %Q(date the API last changed the reference, as <code>dd-mm-yyyy</code>. Wildcards are added at both ends, so <code>07-2026</code> matches a month and <code>2026</code> matches a year)},
+      {field_name: 'api-at-after:', description: "changed by an API after the given date, excluding the date itself"},
+      {field_name: 'api-at-before:', description: "changed by an API before the given date, excluding the date itself -- tip: combine with api-at-after: for a date range"},
+      ].each do |val| %>
+  <tr>
+    <td class="width-20-percent">
+        <a href="javascript:void(0)" class="searchable-field width-100-percent"
+           data-search-directive="<%= val[:field_name] %>"
+           title='Add "<%= val[:field_name] %>" field to search.'>
+          <span class="blue"><%= val[:field_name] %></span>
+        </a>
+    </td>
+    <td><%= val[:description].html_safe %></td>
+  </tr>
+  <% end %>
+</table>
+<br>
+
 <%= render partial: 'help/id_search_help' %>
 
 <h5>Related record IDs</h5>

--- a/app/views/references/advanced_search/_examples.html.erb
+++ b/app/views/references/advanced_search/_examples.html.erb
@@ -146,6 +146,32 @@ in the following formats:</p>
   </tr>
   <% end %>
 </table>
+<br>
+
+<h5>API change searches</h5>
+<p>References changed via the API record the name of the API that changed them and when it happened.  Dates are entered as dd-mm-yyyy in Australia/Melbourne time.</p>
+<table class="example-searches table table-striped">
+  <% [
+      {search_target: 'References', search_string: "has-api-name:",explanation: %Q(References that have been changed by an API.)},
+      {search_target: 'References', search_string: "has-no-api-name:",explanation: %Q(References that have never been changed by an API.)},
+      {search_target: 'References', search_string: "api-name: jira-sync",explanation: %Q(References last changed by an API whose name contains "jira-sync". Case-insensitive, with wildcards added at both ends.)},
+      {search_target: 'References', search_string: "api-at: 27-07-2026",explanation: %Q(References changed by an API on 27 July 2026.)},
+      {search_target: 'References', search_string: "api-at: 07-2026",explanation: %Q(References changed by an API in July 2026 - the date is matched with wildcards at both ends.)},
+      {search_target: 'References', search_string: "api-at: 2026",explanation: %Q(References changed by an API in 2026.)},
+      {search_target: 'References', search_string: "api-at-after: 26-07-2026",explanation: %Q(References changed by an API after 26 July 2026, excluding the 26th itself.)},
+      {search_target: 'References', search_string: "api-at-before: 28-07-2026",explanation: %Q(References changed by an API before 28 July 2026, excluding the 28th itself.)},
+      {search_target: 'References', search_string: "api-at-after: 26-07-2026 api-at-before: 28-07-2026",explanation: %Q(References changed by an API within a date range - here, 27 July 2026 only.)},
+      {search_target: 'References', search_string: "api-name: jira-sync api-at-after: 30-06-2026",explanation: %Q(References changed by the "jira-sync" API after 30 June 2026.)},
+      {search_target: 'References', search_string: "chah api-at: 2026",explanation: %Q(A leading search term like 'chah' is matched against citation, as usual.)},
+      ].each do |val| %>
+  <tr>
+    <td class="width-30-percent">
+      <%= link_to(val[:search_string], search_path(query_string: val[:search_string], query_target: val[:search_target]),class:'blue', title: "Run the described search.") %>
+    </td>
+    <td><%= val[:explanation].html_safe %></td>
+  </tr>
+  <% end %>
+</table>
 
 </div>
 

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 30-July-2026
+  :jira_id: '5860'
+  :description: |-
+    Query directives for api_name and api_at in reference search
+- :date: 30-July-2026
   :jira_id: '5870'
   :description: |-
     Name Count: Fix name count error and restore other files overlooked during the merge on 6 July

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.71
+appversion=5.1.4.72

--- a/test/models/search/on_reference/api_at/simple_test.rb
+++ b/test/models/search/on_reference/api_at/simple_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+
+# Search model tests for the api-at: / api-at-after: / api-at-before:
+# reference search directives.
+class SearchOnReferenceApiAtSimpleTest < ActiveSupport::TestCase
+  DISPLAY_ZONE = "Australia/Melbourne"
+
+  setup do
+    Time.use_zone(DISPLAY_ZONE) do
+      references(:paper_by_brassard)
+        .update_columns(api_at: Time.zone.parse("2026-07-27 09:00"))
+      references(:book_by_brassard)
+        .update_columns(api_at: Time.zone.parse("2026-08-15 12:00"))
+      references(:journal_with_papers).update_columns(api_at: nil)
+    end
+  end
+
+  def search_ids(query_string)
+    params = ActiveSupport::HashWithIndifferentAccess.new(
+      query_target: "reference",
+      query_string: query_string,
+      current_user: build_edit_user
+    )
+    search = Search::Base.new(params)
+    search.executed_query.results.collect(&:id)
+  end
+
+  test "api-at: matches a reference changed on that date" do
+    assert_includes search_ids("api-at: 27-07-2026"),
+                    references(:paper_by_brassard).id,
+                    "Expected the reference changed on 27-07-2026 in the results"
+  end
+
+  test "api-at: excludes a reference changed on another date" do
+    refute_includes search_ids("api-at: 27-07-2026"),
+                    references(:book_by_brassard).id,
+                    "Expected the reference changed on 15-08-2026 to be excluded"
+  end
+
+  test "api-at: uses the display timezone, not UTC" do
+    refute_includes search_ids("api-at: 26-07-2026"),
+                    references(:paper_by_brassard).id,
+                    "9am on the 27th in #{DISPLAY_ZONE} must not match the 26th"
+  end
+
+  test "api-at: matches on month and year alone" do
+    assert_includes search_ids("api-at: 07-2026"),
+                    references(:paper_by_brassard).id,
+                    "Expected a month-and-year search to match"
+    refute_includes search_ids("api-at: 07-2026"),
+                    references(:book_by_brassard).id,
+                    "Expected a reference changed in August to be excluded"
+  end
+
+  test "api-at: matches on year alone" do
+    ids = search_ids("api-at: 2026")
+    assert_includes ids, references(:paper_by_brassard).id,
+                    "Expected a year search to match the July reference"
+    assert_includes ids, references(:book_by_brassard).id,
+                    "Expected a year search to match the August reference"
+  end
+
+  test "api-at: excludes references that have never been changed by the api" do
+    refute_includes search_ids("api-at: 2026"),
+                    references(:journal_with_papers).id,
+                    "Expected a reference with no api_at to be excluded"
+  end
+
+  test "api-at: does not match against the publication date" do
+    refute_includes search_ids("api-at: 1987"),
+                    references(:paper_by_brassard).id,
+                    "api-at: must search api_at, not the publication date"
+  end
+
+  test "api-at-after: excludes the named day itself" do
+    refute_includes search_ids("api-at-after: 27-07-2026"),
+                    references(:paper_by_brassard).id,
+                    "Expected after: to exclude references changed on that same day"
+  end
+
+  test "api-at-after: includes a reference changed on a later day" do
+    ids = search_ids("api-at-after: 26-07-2026")
+    assert_includes ids, references(:paper_by_brassard).id,
+                    "Expected the 27th to be after the 26th"
+    assert_includes ids, references(:book_by_brassard).id,
+                    "Expected the 15th of August to be after the 26th of July"
+  end
+
+  test "api-at-before: excludes the named day itself" do
+    refute_includes search_ids("api-at-before: 27-07-2026"),
+                    references(:paper_by_brassard).id,
+                    "Expected before: to exclude references changed on that same day"
+  end
+
+  test "api-at-before: includes a reference changed on an earlier day" do
+    ids = search_ids("api-at-before: 28-07-2026")
+    assert_includes ids, references(:paper_by_brassard).id,
+                    "Expected the 27th to be before the 28th"
+    refute_includes ids, references(:book_by_brassard).id,
+                    "Expected the 15th of August to be excluded"
+  end
+
+  test "api-at-after: and api-at-before: combine into a date range" do
+    ids = search_ids("api-at-after: 26-07-2026 api-at-before: 28-07-2026")
+    assert_includes ids, references(:paper_by_brassard).id,
+                    "Expected the 27th to fall inside the range"
+    refute_includes ids, references(:book_by_brassard).id,
+                    "Expected the 15th of August to fall outside the range"
+  end
+end

--- a/test/models/search/on_reference/api_name/simple_test.rb
+++ b/test/models/search/on_reference/api_name/simple_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+
+# Search model tests for the api-name: / has-api-name: / has-no-api-name:
+# reference search directives.
+class SearchOnReferenceApiNameSimpleTest < ActiveSupport::TestCase
+  # There are more reference fixtures than the default result limit, so
+  # searches that match most of them need an explicit limit to be
+  # deterministic.
+  ALL = "limit: 500"
+
+  setup do
+    references(:paper_by_brassard).update_columns(api_name: "JIRA-Sync")
+    references(:book_by_brassard).update_columns(api_name: "batch-loader")
+    references(:journal_with_papers).update_columns(api_name: nil)
+  end
+
+  def search_ids(query_string)
+    params = ActiveSupport::HashWithIndifferentAccess.new(
+      query_target: "reference",
+      query_string: query_string,
+      current_user: build_edit_user
+    )
+    search = Search::Base.new(params)
+    search.executed_query.results.collect(&:id)
+  end
+
+  test "api-name: matches the reference changed by that api" do
+    assert_includes search_ids("api-name: jira-sync"),
+                    references(:paper_by_brassard).id,
+                    "Expected the reference changed by jira-sync in the results"
+  end
+
+  test "api-name: excludes a reference changed by another api" do
+    refute_includes search_ids("api-name: jira-sync"),
+                    references(:book_by_brassard).id,
+                    "Expected the reference changed by batch-loader to be excluded"
+  end
+
+  test "api-name: ignores case" do
+    assert_includes search_ids("api-name: JIRA-SYNC"),
+                    references(:paper_by_brassard).id,
+                    "Expected the search to be case insensitive"
+  end
+
+  test "api-name: adds wildcards at both ends" do
+    assert_includes search_ids("api-name: sync"),
+                    references(:paper_by_brassard).id,
+                    "Expected a partial search term to match"
+    assert_includes search_ids("api-name: loader"),
+                    references(:book_by_brassard).id,
+                    "Expected a partial search term to match"
+  end
+
+  test "api-name: excludes a reference never changed by an api" do
+    refute_includes search_ids("api-name: sync"),
+                    references(:journal_with_papers).id,
+                    "Expected a reference with no api_name to be excluded"
+  end
+
+  test "has-api-name: includes a reference changed by an api" do
+    ids = search_ids("has-api-name: #{ALL}")
+    assert_includes ids, references(:paper_by_brassard).id,
+                    "Expected the reference changed by jira-sync in the results"
+    assert_includes ids, references(:book_by_brassard).id,
+                    "Expected the reference changed by batch-loader in the results"
+  end
+
+  test "has-api-name: excludes a reference never changed by an api" do
+    refute_includes search_ids("has-api-name: #{ALL}"),
+                    references(:journal_with_papers).id,
+                    "Expected a reference with no api_name to be excluded"
+  end
+
+  test "has-no-api-name: includes a reference never changed by an api" do
+    assert_includes search_ids("has-no-api-name: #{ALL}"),
+                    references(:journal_with_papers).id,
+                    "Expected a reference with no api_name in the results"
+  end
+
+  test "has-no-api-name: excludes a reference changed by an api" do
+    refute_includes search_ids("has-no-api-name: #{ALL}"),
+                    references(:paper_by_brassard).id,
+                    "Expected the reference changed by jira-sync to be excluded"
+  end
+
+  test "the two directives return disjoint result sets" do
+    with_api_name = search_ids("has-api-name: #{ALL}")
+    without_api_name = search_ids("has-no-api-name: #{ALL}")
+    assert_empty with_api_name & without_api_name,
+                 "A reference cannot both have and not have an api name"
+  end
+
+  test "api-name: combines with a leading citation search term" do
+    ids = search_ids("brassard api-name: jira-sync")
+    assert_includes ids, references(:paper_by_brassard).id,
+                    "Expected the citation term and the api name to combine"
+    refute_includes ids, references(:book_by_brassard).id,
+                    "Expected a brassard reference changed by another api to be excluded"
+  end
+end


### PR DESCRIPTION
## Description
Implement api_name and api_at query directives for reference search

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [ ] Bumped version
- [ ] Updated changelog (Please add an entry to the changelog for the current year)
