### PR TITLE
NSL-5871:  Technical: Remove trailing whitespace from Ruby files - BAU workflow testing only

### DIFF
--- a/app/controllers/concerns/loader/names/parent_typeahead.rb
+++ b/app/controllers/concerns/loader/names/parent_typeahead.rb
@@ -2,10 +2,10 @@ module Loader::Names::ParentTypeahead
   def work_out_parent_from_typeahead
     if params[:loader_name][:parent_typeahead].blank?
       params[:loader_name][:parent_id] = nil
-    else 
-      check_for_mismatched_parent_typeahead 
+    else
+      check_for_mismatched_parent_typeahead
     end
-  end  
+  end
 
   # They've selected one from typeahead
   def matched_parent_typeahead_and_id?

--- a/app/controllers/concerns/name/typeaheads.rb
+++ b/app/controllers/concerns/name/typeaheads.rb
@@ -42,7 +42,7 @@ module Name::Typeaheads
   end
 
   private
-  
+
   def typeahead_params
     params.require(:name).permit(:author_id,
                                  :ex_author_id,

--- a/app/controllers/concerns/search/query_defaults.rb
+++ b/app/controllers/concerns/search/query_defaults.rb
@@ -57,7 +57,7 @@ module Search::QueryDefaults
     regex = /default-batch:.*(?= [A-Za-z-]*:)/
     params[:query_string].sub!(regex, '') if params[:query_string].match?(regex)
   end
-  
+
 
   def remove_old_default_at_end_of_string
     regex = /default-batch:\s[^:]{1,500}\s*$/

--- a/app/controllers/history_controller.rb
+++ b/app/controllers/history_controller.rb
@@ -21,7 +21,7 @@ class HistoryController < ApplicationController
 
   def for_year
     if Rails.configuration.try('jira_status_aware')
-      JiraTicket.keys = JiraTicket.keys_for_year(history_params[:year].to_i) 
+      JiraTicket.keys = JiraTicket.keys_for_year(history_params[:year].to_i)
       JiraTicket.query_keys
       @tickets = JiraTicket.results
     else

--- a/app/controllers/loader/batch/bulk_controller/create_draft_instance_job.rb
+++ b/app/controllers/loader/batch/bulk_controller/create_draft_instance_job.rb
@@ -42,7 +42,7 @@ class Loader::Batch::BulkController::CreateDraftInstanceJob
   end
 
   private
-  
+
   def record_elapsed
     finish_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     @job_h[:time_seconds] = (finish_time - @start_time).round(1)

--- a/app/controllers/loader/batch/bulk_controller/remove_syn_conflicts_job.rb
+++ b/app/controllers/loader/batch/bulk_controller/remove_syn_conflicts_job.rb
@@ -35,7 +35,7 @@ class Loader::Batch::BulkController::RemoveSynConflictsJob
               Job_search: @search_string,
               attempts: 0, creates: 0, declines: 0, errors: 0}
     @search.order(:seq).each do |tree_join_record|
-      if preflight_checks_pass?(tree_join_record) 
+      if preflight_checks_pass?(tree_join_record)
         do_one_instance(tree_join_record)
         # trial to avoid catastrophic failures in Services/Mapper
         sleep(Rails.configuration.try('bulk_job_delay_seconds') || 5)
@@ -50,7 +50,7 @@ class Loader::Batch::BulkController::RemoveSynConflictsJob
   end
 
   private
-    
+
   def record_elapsed
     finish_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     @job_h[:time_seconds] = (finish_time - @start_time).round(1)
@@ -58,7 +58,7 @@ class Loader::Batch::BulkController::RemoveSynConflictsJob
       @job_h[:time] = "#{((finish_time - @start_time)/60).round} min #{((finish_time - @start_time)%60).round} sec"
     end
   end
- 
+
   def preflight_checks_pass?(tree_join_record)
     preflight_check_for_nfp(tree_join_record)
     preflight_check_for_sub_taxa(tree_join_record)
@@ -92,7 +92,7 @@ class Loader::Batch::BulkController::RemoveSynConflictsJob
                                                         @job_number)
     result = taxo_remover.remove
     @job_h.deep_merge!(taxo_remover.result_h) { |key, old, new| old + new}
- 
+
   rescue StandardError => e
     Rails.logger.error("Loader::Batch::BulkController::RemoveSynConflictsJob.do_one_instance: #{e}")
     entry = "<span class='red'>Error: remove syn conflict failed</span>: #{e}"

--- a/app/controllers/loader/batches_controller.rb
+++ b/app/controllers/loader/batches_controller.rb
@@ -40,8 +40,8 @@ class Loader::BatchesController < ApplicationController
 
   def new_row
     @random_id = (Random.new.rand * 10_000_000_000).to_i
-    render :new_row, 
-           locals: {partial: 'new_row', 
+    render :new_row,
+           locals: {partial: 'new_row',
                     locals_for_partial:
                {tab_path: "#{loader_batch_new_with_random_id_path(@random_id)}",
                 link_id: "link-new-loader-batch-#{@random_id}",

--- a/app/controllers/loader/name/review/comments_controller.rb
+++ b/app/controllers/loader/name/review/comments_controller.rb
@@ -51,7 +51,7 @@ class Loader::Name::Review::CommentsController < ApplicationController
     @review_comment = Loader::Name::Review::Comment.find(review_comment_params[:id])
 
     unless @review_comment.batch_review_period.active? || @current_user.batch_loader?
-      raise 'Update not permitted because Review is not active' 
+      raise 'Update not permitted because Review is not active'
     end
     raise 'You cannot update a comment that is not your own' unless @current_user.username == @review_comment.reviewer.user.user_name
     @message = @review_comment.update_if_changed(review_comment_params,

--- a/app/controllers/loader/names_controller.rb
+++ b/app/controllers/loader/names_controller.rb
@@ -56,8 +56,8 @@ class Loader::NamesController < ApplicationController
 
   def new_row
     @random_id = (Random.new.rand * 10_000_000_000).to_i
-    render :new_row, 
-           locals: {partial: 'new_row', 
+    render :new_row,
+           locals: {partial: 'new_row',
                     locals_for_partial:
                {tab_path: "#{loader_name_new_with_random_id_path(@random_id)}",
                 link_id: "link-new-loader-name-#{@random_id}",
@@ -69,8 +69,8 @@ class Loader::NamesController < ApplicationController
 
   def new_heading_row
     @random_id = (Random.new.rand * 10_000_000_000).to_i
-    render :new_row, 
-           locals: {partial: 'new_row', 
+    render :new_row,
+           locals: {partial: 'new_row',
                     locals_for_partial:
                {tab_path: "#{loader_name_heading_new_with_random_id_path(@random_id)}",
                 link_id: "link-new-loader-name-#{@random_id}",
@@ -82,8 +82,8 @@ class Loader::NamesController < ApplicationController
 
   def new_in_batch_note_row
     @random_id = (Random.new.rand * 10_000_000_000).to_i
-    render :new_row, 
-           locals: {partial: 'new_row', 
+    render :new_row,
+           locals: {partial: 'new_row',
                     locals_for_partial:
                {tab_path: "#{loader_name_in_batch_note_new_with_random_id_path(@random_id)}",
                 link_id: "link-new-loader-name-#{@random_id}",
@@ -183,16 +183,16 @@ class Loader::NamesController < ApplicationController
   end
 
   # Note: this is (too) complicated
-  # The reason is it complicated: it is handling creates coming from 
+  # The reason is it complicated: it is handling creates coming from
   # simple actions in the loader interface, but it's also handling
   # creates from over in apni data.
   def create
     insist_on_a_batch unless params["form-task"] == "supplement-existing-concept"
     if loader_name_params["loaded_from_instance_id"].blank?
       @loader_name = Loader::Name.create(loader_name_params, current_user.username)
-    else 
+    else
       create_when_loaded_from_existing_instance
-    end 
+    end
     render "create"
   rescue StandardError => e
     logger.error("Controller:Loader::Names:create:rescuing exception #{e}")
@@ -218,7 +218,7 @@ class Loader::NamesController < ApplicationController
 
 
   def create_heading
-    Loader::Name.create_family_heading(params) 
+    Loader::Name.create_family_heading(params)
     @message = 'Created - the record will be available next time you query the family'
   rescue StandardError => e
     logger.error("Loader::NamesController#create_heading rescuing #{e}")
@@ -243,11 +243,11 @@ class Loader::NamesController < ApplicationController
   end
 
   def insist_on_a_batch
-    if session[:default_loader_batch_name].blank? && 
+    if session[:default_loader_batch_name].blank? &&
         loader_name_params[:loader_batch_id].blank?
       raise "Please set a default batch"
     end
-  end 
+  end
 
   # This is for creates started over in the Name records.
   # It has more complicated requirements than a simple create inside the loader.
@@ -336,7 +336,7 @@ class Loader::NamesController < ApplicationController
 
   def embedded_parent_typeahead_id(typeahead_value)
     raise ArgumentError, "Input too long" if typeahead_value.length > 1000
-    typeahead_value.sub(/.*\(/,'').sub(/\).*/,'') 
+    typeahead_value.sub(/.*\(/,'').sub(/\).*/,'')
   end
 
   def current_families

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -43,8 +43,8 @@ class ReferencesController < ApplicationController
   # GET /references/new_row
   def new_row
     @random_id = (Random.new.rand * 10_000_000_000).to_i
-    render :new_row, 
-      locals: {partial: 'new_row', 
+    render :new_row,
+      locals: {partial: 'new_row',
                 locals_for_partial:
                   {tab_path: "#{new_reference_with_random_id_path(@random_id)}",
                    link_id: "link-new-reference-#{@random_id}",

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -31,7 +31,7 @@ class SessionsController < ApplicationController
 
   # Known problem: if login is rejected due to no login authority
   # entering a legit username/password into the re-rendered sign in form
-  # fails the first time.  
+  # fails the first time.
   def create
     build_sign_in
     if @sign_in.save && authorised_to_login?
@@ -93,7 +93,7 @@ class SessionsController < ApplicationController
     sign_in_params = params[:sign_in]
     sign_in_params&.permit(:username, :password)
   end
-  
+
   def authorised_to_login?
     if @sign_in.groups.include?('login')
       true

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -282,7 +282,7 @@ class TreesController < ApplicationController
     render "trees/reports/run_cas_error", status: :forbidden
   rescue => e
     @message = e.to_s
-    render "trees/reports/run_cas_error", status: :bad_request 
+    render "trees/reports/run_cas_error", status: :bad_request
   end
 
   def show_diff
@@ -309,7 +309,7 @@ class TreesController < ApplicationController
     render "trees/reports/run_diff_error", status: :forbidden
   rescue => e
     @message = e.to_s
-    render "trees/reports/run_diff_error", status: :bad_request 
+    render "trees/reports/run_diff_error", status: :bad_request
   end
 
   def show_valrep
@@ -332,7 +332,7 @@ class TreesController < ApplicationController
     render "trees/reports/run_valrep_error", status: :forbidden
   rescue => e
     @message = e.to_s
-    render "trees/reports/run_valrep_error", status: :bad_request 
+    render "trees/reports/run_valrep_error", status: :bad_request
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,8 +34,8 @@ class UsersController < ApplicationController
   # GET /user/new_row
   def new_row
     @random_id = (Random.new.rand * 10_000_000_000).to_i
-    render :new_row, 
-       locals: {partial: 'new_row', 
+    render :new_row,
+       locals: {partial: 'new_row',
                 locals_for_partial:
                   {tab_path: "#{new_user_with_random_id_path(@random_id)}",
                    link_id: "link-new-user-#{@random_id}",

--- a/app/helpers/loader/names_helper.rb
+++ b/app/helpers/loader/names_helper.rb
@@ -50,7 +50,7 @@ module Loader::NamesHelper
   end
 
   def capture_family(search_result)
-    @previous_family = search_result.family 
+    @previous_family = search_result.family
   end
 
   def will_show_family(white_space)

--- a/app/models/concerns/instance/for_copy_to_loader_name.rb
+++ b/app/models/concerns/instance/for_copy_to_loader_name.rb
@@ -6,7 +6,7 @@ module Instance::ForCopyToLoaderName
   class_methods do
     def sourced_sibling_synonyms_and_misapps(instance)
       Instance.where(cited_by_id: instance.this_is_cited_by)
-              .where.not(id: instance.id) 
+              .where.not(id: instance.id)
               .joins(:instance_type)
               .where(instance_type: { unsourced: false })
               .where.not(instance_type: { name: 'trade name' })

--- a/app/models/concerns/loader/batch/sort_key.rb
+++ b/app/models/concerns/loader/batch/sort_key.rb
@@ -21,7 +21,7 @@ update loader_name
 SQL
 
 
-  # Synonyms sort_key will be supplemented with the 
+  # Synonyms sort_key will be supplemented with the
   # taxon_name_usage_v.usage_order value
   # for better ordering
   def refresh_synonym_sort_keys

--- a/app/models/concerns/loader/name/doubt.rb
+++ b/app/models/concerns/loader/name/doubt.rb
@@ -1,6 +1,6 @@
 module Loader::Name::Doubt
   extend ActiveSupport::Concern
-  
+
   # We take special care with doubtfulness.
   # The doubtful boolean column comes from the era of parsed data
   # and we need to keep it for those batches, but
@@ -9,7 +9,7 @@ module Loader::Name::Doubt
   #
   # This method may need to be adjusted to clarify rules in future.
   def doubtful?
-    if synonym_type.present? 
+    if synonym_type.present?
       return true if self.synonym_type.match(/doubtful/)
     else
       return true if self.doubtful == true
@@ -20,12 +20,12 @@ module Loader::Name::Doubt
 
   # The method below is for use in the riti method.
   #
-  # riti is used to determine the relationship instance type when 
+  # riti is used to determine the relationship instance type when
   # creating a preferred match
   #
-  # The above doubtful? method was being called in riti but was creating 
+  # The above doubtful? method was being called in riti but was creating
   # problems because it ignores the doubtful field when synonym type is present
-  # - and synonym_type is usually present in parsed synonyms, but, as parsed, 
+  # - and synonym_type is usually present in parsed synonyms, but, as parsed,
   # it ignores doubt # because doubt was recorded in a separate doubtful field.
   #
   def riti_doubtful?

--- a/app/models/concerns/loader/name/in_batch_compiler_note.rb
+++ b/app/models/concerns/loader/name/in_batch_compiler_note.rb
@@ -14,7 +14,7 @@ module Loader::Name::InBatchCompilerNote
     self.simple_name = NA if simple_name.blank?
     self.full_name = simple_name
   end
-  
+
   def in_batch_compiler_note_sort_key
     if family == NA && simple_name == NA
       "aaaa-in-batch-compiler-note"

--- a/app/models/concerns/loader/name/in_batch_note.rb
+++ b/app/models/concerns/loader/name/in_batch_note.rb
@@ -14,7 +14,7 @@ module Loader::Name::InBatchNote
     self.simple_name = NA if simple_name.blank?
     self.full_name = simple_name
   end
-  
+
   def in_batch_note_sort_key
     if family == NA && simple_name == NA
       "aaaa-in-batch-note"

--- a/app/models/concerns/loader/name/partials.rb
+++ b/app/models/concerns/loader/name/partials.rb
@@ -3,7 +3,7 @@ module Loader::Name::Partials
 
   # synonym_type takes precedence
   def partial_misapplied?
-    unless synonym_type.blank? 
+    unless synonym_type.blank?
       synonym_type&.match?(/pro parte/)
     else
       publ_partly&.match(/p\.p\./)

--- a/app/models/concerns/loader/name/review_comments.rb
+++ b/app/models/concerns/loader/name/review_comments.rb
@@ -8,7 +8,7 @@ module Loader::Name::ReviewComments
   def narrow_direct_reviewer_comments
     real_record_comments(Loader::Batch::Review::Role::NAME_REVIEWER)
   end
-  
+
   def narrow_direct_reviewer_comments?
     narrow_direct_reviewer_comments.size > 0
   end
@@ -41,7 +41,7 @@ module Loader::Name::ReviewComments
   end
 
   def compiler_comments
-    [narrow_direct_compiler_comments, 
+    [narrow_direct_compiler_comments,
      concept_note_compiler_comments,
      distribution_compiler_comments,
      children_compiler_comments].flatten
@@ -68,7 +68,7 @@ module Loader::Name::ReviewComments
   # Comments on children
 
   def children_reviewer_comments
-    children.map do |child| 
+    children.map do |child|
       child.name_review_comments
       .includes(batch_reviewer: [:batch_review_role])
       .select { |comment| comment.reviewer.role.name == Loader::Batch::Review::Role::NAME_REVIEWER }
@@ -76,7 +76,7 @@ module Loader::Name::ReviewComments
   end
 
   def children_compiler_comments
-    children.map do |child| 
+    children.map do |child|
       child.name_review_comments
       .includes(batch_reviewer: [:batch_review_role])
       .select { |comment| comment.reviewer.role.name == Loader::Batch::Review::Role::COMPILER }
@@ -85,7 +85,7 @@ module Loader::Name::ReviewComments
 
 
   # Comments on pretend records
-  
+
   def concept_note_reviewer_comments
     pretend_record_comments(Loader::Batch::Review::Role::NAME_REVIEWER, 'concept-note')
   end

--- a/app/models/concerns/loader/name/seq_calculator.rb
+++ b/app/models/concerns/loader/name/seq_calculator.rb
@@ -63,7 +63,7 @@ module Loader::Name::SeqCalculator
         Loader::Batch.find(params["loader_batch_id"])
       elsif params["parent_id"]
         Loader::Name.find(params["parent_id"]).loader_batch
-      else 
+      else
         nil
       end
     end

--- a/app/models/concerns/loader/name/sibling_synonyms.rb
+++ b/app/models/concerns/loader/name/sibling_synonyms.rb
@@ -6,7 +6,7 @@ module Loader::Name::SiblingSynonyms
       siblings = Instance.sourced_sibling_synonyms_and_misapps(syn)
       seq_value = loader_batch.use_sort_key_for_ordering ? 0 : seq
       logger.debug("batch id: #{loader_batch_id}")
-      siblings.each do |instance| 
+      siblings.each do |instance|
         seq_value += 1 unless loader_batch.use_sort_key_for_ordering
         s = ::Loader::Name.new(loader_batch_id: loader_batch_id,
                                record_type: syn_or_misapp(instance),
@@ -26,7 +26,7 @@ module Loader::Name::SiblingSynonyms
                                seq: seq_value
                               )
         s.consider_sort_key
-        s.attribute_names.each do |a| 
+        s.attribute_names.each do |a|
           logger.debug("#{a} : #{s[a]}") unless s[a].blank?
         end
         s.save!

--- a/app/models/concerns/loader/name/sort_key.rb
+++ b/app/models/concerns/loader/name/sort_key.rb
@@ -13,7 +13,7 @@ module Loader::Name::SortKey
   def should_reset_sort_key?
     return false if %w(in-batch-note in-batch-compile-note heading).include? record_type
     return true if self.changed? && !self.changes_to_save.keys.include?('sort_key')
-    false    
+    false
   end
 
   def set_sort_key
@@ -54,7 +54,7 @@ module Loader::Name::SortKey
     raise
   end
 
-  # This is for when we are combining our sort_key algorithm with a synonym sort 
+  # This is for when we are combining our sort_key algorithm with a synonym sort
   # value from taxon_mv(_new) - we want enough of a sort_key for the synonym
   # to place it under its parent, but not enough to determine its sorting
   # position within other synonyms for that parent.

--- a/app/models/concerns/loader/name/sourced_synonyms.rb
+++ b/app/models/concerns/loader/name/sourced_synonyms.rb
@@ -6,7 +6,7 @@ module Loader::Name::SourcedSynonyms
       sourced_syns = instance.synonyms_for_copy_to_loader_name
 
       seq_value = loader_batch.use_sort_key_for_ordering ? 0 : seq
-      sourced_syns.each do |sou_syn| 
+      sourced_syns.each do |sou_syn|
         seq_value += 1 unless loader_batch.use_sort_key_for_ordering
         s = ::Loader::Name.new(loader_batch_id: loader_batch_id,
                                record_type: syn_or_misapp(sou_syn),

--- a/app/models/concerns/name/instances_copyable.rb
+++ b/app/models/concerns/name/instances_copyable.rb
@@ -24,7 +24,7 @@ module Name::InstancesCopyable
     copy_tally = 0
     Name.transaction do
       verified_requested_instances(requested_instance_ids).each do |instance|
-        instance.copy_to_new_name(target_name.id, as_username)  
+        instance.copy_to_new_name(target_name.id, as_username)
         copy_tally += 1
       end
     end

--- a/app/models/instance/as_edited.rb
+++ b/app/models/instance/as_edited.rb
@@ -116,7 +116,7 @@ class Instance::AsEdited < Instance
     end
   end
 
-  # I tried not calling this method but found blanks entered into a text field 
+  # I tried not calling this method but found blanks entered into a text field
   # were detected as a change, so the record was updated!  Even though the blanks
   # never made it into the database, presume thanks to strip_attributes!
   def clean_all(params)

--- a/app/models/instance/as_typeahead/for_synonymy.rb
+++ b/app/models/instance/as_typeahead/for_synonymy.rb
@@ -120,7 +120,7 @@ class Instance::AsTypeahead::ForSynonymy
     match = terms.match(/[1,2][0-9]{3}/)
     return reference_binds if match.blank?
 
-    reference_year = match.to_s 
+    reference_year = match.to_s
     if reference_year.present? &&
        reference_year.to_i > 1000 && reference_year.to_i < 3000
       reference_binds.push(" reference.iso_publication_date like ? ||'%' ")

--- a/app/models/jira_ticket.rb
+++ b/app/models/jira_ticket.rb
@@ -47,11 +47,11 @@ class JiraTicket < ActiveType::Object
   def self.keys=(array_of_keys)
     @keys = array_of_keys
   end
-  
+
   def self.keys_to_query=(list_of_keys_to_query)
     @keys_to_query = list_of_keys_to_query
   end
-  
+
   def self.jql(keys_array)
     "key in (#{keys_array.join(', ')})"
   end

--- a/app/models/loader/batch.rb
+++ b/app/models/loader/batch.rb
@@ -41,7 +41,7 @@ class Loader::Batch < ApplicationRecord
 
     loader_batch
   end
-  
+
   def save_with_username(username)
     self.created_by = self.updated_by = username
     save
@@ -93,7 +93,7 @@ class Loader::Batch < ApplicationRecord
       "No change"
     end
   end
-  
+
   def first_n_seq(n = 1)
     self.loader_names.order(:seq).limit(n).pluck(:seq)
   end

--- a/app/models/loader/batch/review/period.rb
+++ b/app/models/loader/batch/review/period.rb
@@ -50,7 +50,7 @@ class Loader::Batch::Review::Period < ApplicationRecord
 
   attr_accessor :give_me_focus, :message
 
-  scope :active, -> { 
+  scope :active, -> {
     where("start_date <= ?", Time.zone.today)
     .where("end_date IS NULL OR end_date >= ?", Time.zone.today)
   }

--- a/app/models/loader/name.rb
+++ b/app/models/loader/name.rb
@@ -98,7 +98,7 @@ class Loader::Name < ApplicationRecord
       child.loader_batch_id = loader_batch_id
       # Have to set sort_key here - the default callback to set it fails
       # because at that point in processing the parent's sort_key is empty
-      child.sort_key = if child.record_type == 'synonym' 
+      child.sort_key = if child.record_type == 'synonym'
                          synonym_sort_key(sort_key, child.synonym_type)
                        elsif child.record_type = 'misapplied'
                          misapp_sort_key(sort_key)
@@ -308,7 +308,7 @@ class Loader::Name < ApplicationRecord
 
     if taxonomic?
       return InstanceType.find_by_name("doubtful pro parte taxonomic synonym").id if riti_doubtful? && pp?
-      
+
       return InstanceType.find_by_name("doubtful taxonomic synonym").id if riti_doubtful?
 
       return InstanceType.find_by_name("pro parte taxonomic synonym").id if pp?
@@ -400,7 +400,7 @@ class Loader::Name < ApplicationRecord
 
     loader_name
   end
-  
+
   def save_with_username(username)
     self.created_by = self.updated_by = username
     set_defaults

--- a/app/models/loader/name/bulk_search.rb
+++ b/app/models/loader/name/bulk_search.rb
@@ -75,7 +75,7 @@ class Loader::Name::BulkSearch
   # Family clause can be like this
   #
   #     family: one-family-name*
-  # 
+  #
   # which can have wildcard because converted to SQL like
   #
   #     family like 'one-family-name%'

--- a/app/models/loader/name/draft_taxonomy_adder/preflights.rb
+++ b/app/models/loader/name/draft_taxonomy_adder/preflights.rb
@@ -40,7 +40,7 @@ class Loader::Name::DraftTaxonomyAdder::Preflights
     when @loader_name.preferred_match.blank?
       cleared = false
       preflight_error = "No preferred match"
-    when @loader_name.preferred_match.blank? || 
+    when @loader_name.preferred_match.blank? ||
          @loader_name.preferred_match.standalone_instance_id.blank?
       cleared = false
       preflight_error = "No instance identified"

--- a/app/models/loader/name/make_one_match.rb
+++ b/app/models/loader/name/make_one_match.rb
@@ -36,7 +36,7 @@ class Loader::Name::MakeOneMatch
     return decline("heading") if @loader_name.heading?
     return decline("parent_using_existing") if @loader_name.parent&.preferred_match&.use_existing_instance
 
-    return decline("not_exactly_one_match")  unless exactly_one_matching_name? 
+    return decline("not_exactly_one_match")  unless exactly_one_matching_name?
     return decline("match_has_no_primary_instance") unless match_name_has_primary?
     return decline("match_has_2_or_more_primary_instances") unless match_name_just_one_primary?
 

--- a/app/models/loader/name/match.rb
+++ b/app/models/loader/name/match.rb
@@ -31,9 +31,9 @@ class Loader::Name::Match < ApplicationRecord
   belongs_to :relationship_instance, class_name: "::Instance",
                 foreign_key: "relationship_instance_id", optional: true
 
-  # would like to deprecate instance_type in favour of 
+  # would like to deprecate instance_type in favour of
   # relationship_instance_type
-  belongs_to :instance_type, 
+  belongs_to :instance_type,
                 foreign_key: :relationship_instance_type_id, optional: true
   belongs_to :relationship_instance_type, class_name: "::InstanceType",
                 foreign_key: "relationship_instance_type_id", optional: true

--- a/app/models/loader/name/match/as_typeahead/for_intended_tree_parent_instance.rb
+++ b/app/models/loader/name/match/as_typeahead/for_intended_tree_parent_instance.rb
@@ -43,9 +43,9 @@ class Loader::Name::Match::AsTypeahead::ForIntendedTreeParentInstance
 
   # Select on full name
   # Show full name and name status (unless 'legitimate')
-  # CodeQL on github alerts to this query, in particular to the use of 
-  # prepared_search_term to pass param value into the query - but the code 
-  # follows the Rails guide technique for passing values into a query via 
+  # CodeQL on github alerts to this query, in particular to the use of
+  # prepared_search_term to pass param value into the query - but the code
+  # follows the Rails guide technique for passing values into a query via
   # a placeholder in a way that specifically counters SQL Injection.
   # I will dismiss the alert.
   def core_query

--- a/app/models/loader/name/review/vote.rb
+++ b/app/models/loader/name/review/vote.rb
@@ -75,7 +75,7 @@ class Loader::Name::Review::Vote < ApplicationRecord
   end
 
   # Sample params:
-  # params: "loader_name_id"=>"51739066", 
+  # params: "loader_name_id"=>"51739066",
   #         "batch_review_id"=>"51785034",
   #         "org_id"=>"51614642",
   #         "vote"=>"true"}
@@ -93,6 +93,6 @@ class Loader::Name::Review::Vote < ApplicationRecord
         created += 1
       end
     end
-    created 
+    created
   end
 end

--- a/app/models/name/as_services.rb
+++ b/app/models/name/as_services.rb
@@ -146,7 +146,7 @@ class Name::AsServices < Name
   # need to pass them through to the application GUI.
   #
   # In 2026 I'm finding that Editor is thinking Name is deleted when an error
-  # has occurred in Services - the return code is still 200 from Services and 
+  # has occurred in Services - the return code is still 200 from Services and
   # the json says "ok"
   def delete_with_reason(reason)
     url = Name::AsServices.delete_url(id, reason)

--- a/app/models/name/as_typeahead/on_full_name.rb
+++ b/app/models/name/as_typeahead/on_full_name.rb
@@ -17,7 +17,7 @@
 #   limitations under the License.
 #
 #   A list of names.
-#   Is called from the Reference >  New Instance tab to identify a Name record 
+#   Is called from the Reference >  New Instance tab to identify a Name record
 #   for the Instance.
 class Name::AsTypeahead::OnFullName
   attr_reader :suggestions,

--- a/app/models/name_rank.rb
+++ b/app/models/name_rank.rb
@@ -348,7 +348,7 @@ class NameRank < ApplicationRecord
   #  subdivisions of a genus (i.e. below genus but above species)
   #  infraspecies (i.e. below species)
   def compatible_with_autonym?
-    sort_order > NameRank.genus.sort_order && !species? 
+    sort_order > NameRank.genus.sort_order && !species?
   end
 end
 

--- a/app/models/profile/product_item_config.rb
+++ b/app/models/profile/product_item_config.rb
@@ -37,12 +37,12 @@ module Profile
   class ProductItemConfig < ApplicationRecord
     self.table_name = "product_item_config"
     self.primary_key = "id"
-    
+
     belongs_to :product, class_name: '::Product'
     belongs_to :profile_item_type, class_name: 'Profile::ProfileItemType', foreign_key: 'profile_item_type_id'
 
     has_many :profile_items, class_name: 'Profile::ProfileItem', foreign_key: 'product_item_config_id'
-    
+
     validates :product_id, presence: true
     validates :profile_item_type_id, presence: true
 

--- a/app/models/profile/profile_item_type.rb
+++ b/app/models/profile/profile_item_type.rb
@@ -32,12 +32,12 @@ module Profile
   class ProfileItemType < ApplicationRecord
     self.table_name = "profile_item_type"
     self.primary_key = "id"
-    
+
     belongs_to :profile_object_type, class_name: 'Profile::ProfileObjectType', foreign_key: 'profile_object_type_id'
-    
+
     has_many :product_item_configs, class_name: 'Profile::ProductItemConfig', foreign_key: 'profile_item_type_id'
-    
+
     validates :name, presence: true
   end
 end
-  
+

--- a/app/models/profile/profile_object_type.rb
+++ b/app/models/profile/profile_object_type.rb
@@ -24,7 +24,7 @@ module Profile
   class ProfileObjectType < ApplicationRecord
     self.table_name = "profile_object_type"
     self.primary_key = "id"
-    
+
     has_many :profile_items, class_name: 'Profile::ProfileItem', primary_key: 'rdf_id', foreign_key: 'profile_object_rdf_id'
 
     validates :name, presence: true

--- a/app/models/search/loader/name/field_rule.rb
+++ b/app/models/search/loader/name/field_rule.rb
@@ -103,10 +103,10 @@ class Search::Loader::Name::FieldRule
     "default-batch:" => { where_clause: "loader_batch_id = (select id from loader_batch where lower(name) = ?)  "},
     "id:" => { multiple_values: true,
                where_clause: "id = ? or parent_id = ?
-                              or id = (select parent_id from loader_name my_parent where my_parent.id = ?) 
+                              or id = (select parent_id from loader_name my_parent where my_parent.id = ?)
                               or parent_id = (select parent_id from loader_name my_sibling where my_sibling.id = ?)",
                multiple_values_where_clause: "id in (?) or parent_id in (?)
-                              or id in (select parent_id from loader_name my_parent where my_parent.id in (?)) 
+                              or id in (select parent_id from loader_name my_parent where my_parent.id in (?))
                               or parent_id in (select parent_id from loader_name my_sibling where my_sibling.id in (?))",
                },
     "raw-id:" => { multiple_values: true,
@@ -345,9 +345,9 @@ class Search::Loader::Name::FieldRule
                        takes_no_arg: true},
     "excluded:" => { where_clause: "record_type = 'excluded'",
                        takes_no_arg: true},
-    "not-excluded:" => { where_clause: " record_type != 'excluded'", 
+    "not-excluded:" => { where_clause: " record_type != 'excluded'",
                          takes_no_arg: true},
-    "syn:" => { where_clause: "record_type = 'synonym'", 
+    "syn:" => { where_clause: "record_type = 'synonym'",
                 takes_no_arg: true},
     "misapplied:" => { where_clause: "record_type = 'misapplied'",
                        takes_no_arg: true},
@@ -465,19 +465,19 @@ having count(*) > 2
             from name_Type nt
           where name.name_type_id       = nt.id
      and nt.scientific))"},
-  "name-match-no-primary:" => { 
-    where_clause: 
+  "name-match-no-primary:" => {
+    where_clause:
     "id in (
 select ln.id
-  from loader_name ln 
+  from loader_name ln
  where record_type != 'heading'
    and 1 =
   (select count(*)
-     from name 
+     from name
     where ln.simple_name = name.simple_name)
-   and 1 = 
-  (select count(*) 
-     from name 
+   and 1 =
+  (select count(*)
+     from name
     where ln.simple_name = name.simple_name
       and not exists
       (select null
@@ -678,18 +678,18 @@ select ln.id
     "drafted:" => { where_clause: " id in (select loader_name_id from loader_name_match where drafted)"},
     "created-manually:" => { where_clause: "created_manually" },
 "syn-match-in-tree-faster-join:" => { where_clause: " id in (select ln.id
-  from loader_name ln 
+  from loader_name ln
        join loader_name_match lnm
        on ln.id = lnm.loader_name_id
        join instance_type rel_type
        on lnm.relationship_instance_type_id = rel_type.id
        join instance i
-       on lnm.name_id = i.name_id 
-       join tree_join_v tjv 
-       on i.id = tjv.instance_id 
+       on lnm.name_id = i.name_id
+       join tree_join_v tjv
+       on i.id = tjv.instance_id
        join loader_batch lb
        on ln.loader_batch_id = lb.id
-       join name 
+       join name
        on tjv.name_id = name.id
  where ln.record_type = 'synonym'
    and not tjv.published
@@ -701,18 +701,18 @@ select ln.id
    not_exists_clause: " needs an argument",
    multiple_values: true,
    multiple_values_where_clause: " id in (select ln.id
-  from loader_name ln 
+  from loader_name ln
        join loader_name_match lnm
        on ln.id = lnm.loader_name_id
        join instance_type rel_type
        on lnm.relationship_instance_type_id = rel_type.id
        join instance i
-       on lnm.name_id = i.name_id 
-       join tree_join_v tjv 
-       on i.id = tjv.instance_id 
+       on lnm.name_id = i.name_id
+       join tree_join_v tjv
+       on i.id = tjv.instance_id
        join loader_batch lb
        on ln.loader_batch_id = lb.id
-       join name 
+       join name
        on tjv.name_id = name.id
  where ln.record_type = 'synonym'
    and not tjv.published
@@ -723,18 +723,18 @@ select ln.id
    and lower(ln.simple_name) in (?))",
      },
 "syn-match-in-tree-family:" => { where_clause: " id in (select ln.id
-  from loader_name ln 
+  from loader_name ln
        join loader_name_match lnm
        on ln.id = lnm.loader_name_id
        join instance_type rel_type
        on lnm.relationship_instance_type_id = rel_type.id
        join instance i
-       on lnm.name_id = i.name_id 
-       join tree_join_v tjv 
-       on i.id = tjv.instance_id 
+       on lnm.name_id = i.name_id
+       join tree_join_v tjv
+       on i.id = tjv.instance_id
        join loader_batch lb
        on ln.loader_batch_id = lb.id
-       join name 
+       join name
        on tjv.name_id = name.id
  where ln.record_type = 'synonym'
    and not tjv.published
@@ -746,18 +746,18 @@ select ln.id
    not_exists_clause: " needs an argument",
    multiple_values: true,
    multiple_values_where_clause: " id in (select ln.id
-  from loader_name ln 
+  from loader_name ln
        join loader_name_match lnm
        on ln.id = lnm.loader_name_id
        join instance_type rel_type
        on lnm.relationship_instance_type_id = rel_type.id
        join instance i
-       on lnm.name_id = i.name_id 
-       join tree_join_v tjv 
-       on i.id = tjv.instance_id 
+       on lnm.name_id = i.name_id
+       join tree_join_v tjv
+       on i.id = tjv.instance_id
        join loader_batch lb
        on ln.loader_batch_id = lb.id
-       join name 
+       join name
        on tjv.name_id = name.id
  where ln.record_type = 'synonym'
    and not tjv.published
@@ -884,8 +884,8 @@ select ln.id
                             )
                            )
                          )
-                   or 
-                   parent_id in ( select id from loader_name where 
+                   or
+                   parent_id in ( select id from loader_name where
                                    record_type in ('accepted','excluded')
                                    and (exists ( select null
                                                    from name_review_vote
@@ -894,7 +894,7 @@ select ln.id
                                                         and lower(org.abbrev) like lower(?)
                                                   where loader_name.id = name_review_vote.loader_name_id
                                                     and name_review_vote.vote = true)
-                                       ) 
+                                       )
                                 )"
        },
   "org-voted-no:" => {
@@ -927,8 +927,8 @@ select ln.id
                             )
                            )
                          )
-                   or 
-                   parent_id in ( select id from loader_name where 
+                   or
+                   parent_id in ( select id from loader_name where
                                    record_type in ('accepted','excluded')
                                    and (exists ( select null
                                                    from name_review_vote
@@ -937,7 +937,7 @@ select ln.id
                                                         and lower(org.abbrev) like lower(?)
                                                   where loader_name.id = name_review_vote.loader_name_id
                                                     and name_review_vote.vote = false)
-                                       ) 
+                                       )
                                 )"
        },
   "org-voted:" => {
@@ -968,8 +968,8 @@ select ln.id
                             )
                            )
                          )
-                   or 
-                   parent_id in ( select id from loader_name where 
+                   or
+                   parent_id in ( select id from loader_name where
                                    record_type in ('accepted','excluded')
                                    and (exists ( select null
                                                    from name_review_vote
@@ -977,7 +977,7 @@ select ln.id
                                                         on name_review_vote.org_id = org.id
                                                         and lower(org.abbrev) like lower(?)
                                                   where loader_name.id = name_review_vote.loader_name_id)
-                                       ) 
+                                       )
                                 )",
        },
   "org-not-voted:" => { where_clause: "id not in ( select id from loader_name subq_loader_name where
@@ -1007,8 +1007,8 @@ select ln.id
                             )
                            )
                          )
-                   and 
-                              ( parent_id is null or parent_id not in ( select id from loader_name parent_loader_name where 
+                   and
+                              ( parent_id is null or parent_id not in ( select id from loader_name parent_loader_name where
                                    record_type in ('accepted','excluded')
                                    and (exists ( select null
                                                    from name_review_vote
@@ -1016,12 +1016,12 @@ select ln.id
                                                         on name_review_vote.org_id = org.id
                                                         and lower(org.abbrev) like lower(?)
                                                   where parent_loader_name.id = name_review_vote.loader_name_id)
-                                       ) 
-                                ) 
+                                       )
+                                )
                               )"
        },
-  "no-family-heading:" => { 
-    where_clause: "record_type in ('accepted','excluded') 
+  "no-family-heading:" => {
+    where_clause: "record_type in ('accepted','excluded')
 and not exists
 (select null
   from loader_name family
@@ -1030,14 +1030,14 @@ and not exists
 )",
       takes_no_arg: true,
   },
-"syn-matched-to-autonym:" => { where_clause: "record_type = 'synonym' 
+"syn-matched-to-autonym:" => { where_clause: "record_type = 'synonym'
   and exists (select null
                 from loader_name_match
                      join instance on loader_name_match.instance_id = instance.id
                      join instance_type on instance.instance_type_id = instance_type.id
                where loader_name.id = loader_name_match.loader_name_id
                  and instance_type.name like '%autonym%'
-             )", 
+             )",
             takes_no_arg: true},
   }.freeze
 end

--- a/app/models/search/on_name/with_instances_to_copy.rb
+++ b/app/models/search/on_name/with_instances_to_copy.rb
@@ -19,7 +19,7 @@
 
 # Based on the core search class for Name search
 # Tweaked for copying instances to the loader
-# They don't want common name instances, vernacular name instances, or any other 
+# They don't want common name instances, vernacular name instances, or any other
 # unsourced instances or trade name instances.
 #
 class Search::OnName::WithInstancesToCopy

--- a/app/models/search/on_orchids/where_clauses.rb
+++ b/app/models/search/on_orchids/where_clauses.rb
@@ -51,7 +51,7 @@ class Search::OnOrchids::WhereClauses
       raise "endless loop #{x}" if x > 50
     end
   end
- 
+
   def add_clause(field = 'taxon', value)
     debug("add_clause for field: #{field}; value: #{value}")
     if field.blank? && value.blank?

--- a/app/models/search/parsed_request.rb
+++ b/app/models/search/parsed_request.rb
@@ -461,7 +461,7 @@ class Search::ParsedRequest
   # Note limitation of the checks: doesn't care if result of search is in only
   # one batch.
   #
-  # Note: default-batch is deliberately case-sensitive due to its more complex 
+  # Note: default-batch is deliberately case-sensitive due to its more complex
   # processing at this time.
   # Called via send
   def preprocess_loader_names
@@ -472,7 +472,7 @@ class Search::ParsedRequest
            @params["query_string"].match(/\bany-batch:/i) ||
            @params["query_string"].match(/[^-]id:/i) ||
            @params["query_string"].match(/\Aid:/i) ||
-           @params["query_string"].match(/\bid-with-syn:/i) 
+           @params["query_string"].match(/\bid-with-syn:/i)
       raise "Please set a default batch, or specify a 'batch-id:', a 'batch-name:' or 'any-batch:'"
     end
   end

--- a/app/models/search/reference/field_rule.rb
+++ b/app/models/search/reference/field_rule.rb
@@ -206,8 +206,8 @@ inner join ref_type xcrt on xrt.id = xcrt.parent_id))",
                      multiple_values_where_clause: " source_id in (?)" },
     "source-id-string:" => {where_clause: "lower(source_id_string) like ?||'%'"},
     "is-a-duplicate-and-master:" => { where_clause: " id in (select id
-                                                               from reference ref_dupe_master 
-                                                              where id in (select duplicate_of_id 
+                                                               from reference ref_dupe_master
+                                                              where id in (select duplicate_of_id
                                                                              from reference ref_dupes
                                                                             where duplicate_of_id is not null)
                                                               and duplicate_of_id is not null)",
@@ -227,7 +227,7 @@ inner join ref_type xcrt on xrt.id = xcrt.parent_id))",
                           leading_wildcard: true,
                           where_clause:
                                  " lower(display_title) like lower(?)" },
-    "title-does-not-match-display-title:" => { 
+    "title-does-not-match-display-title:" => {
                           takes_no_arg: true,
                           where_clause: " display_title != title " },
   }.freeze

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 30-July-2026
+  :jira_id: '5871'
+  :description: |-
+    Technical: Remove trailing whitespace from Ruby files - BAU workflow testing only
+- :date: 30-July-2026
   :jira_id: '5860'
   :description: |-
     Query directives for api_name and api_at in reference search

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 30-July-2026
+  :jira_id: '5871'
+  :description: |-
+    Technical: Remove trailing whitespace from Ruby files - BAU workflow testing only
+- :date: 30-July-2026
   :jira_id: '5870'
   :description: |-
     Name Count: Fix name count error and restore other files overlooked during the merge on 6 July

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,8 +1,4 @@
 - :date: 30-July-2026
-  :jira_id: '5871'
-  :description: |-
-    Technical: Remove trailing whitespace from Ruby files - BAU workflow testing only
-- :date: 30-July-2026
   :jira_id: '5870'
   :description: |-
     Name Count: Fix name count error and restore other files overlooked during the merge on 6 July

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.72
+appversion=5.1.4.73

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.71
+appversion=5.1.4.72

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.72
+appversion=5.1.4.71

--- a/spec/views/names/tabs/tabs_partial_spec.rb
+++ b/spec/views/names/tabs/tabs_partial_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe("names/tabs/_tabs.html.erb", type: :view) do
     allow(view).to(receive(:can?).with(:update_common_name, name).and_return(false))
     allow(view).to(receive(:can?).with(:create_common_name, Name).and_return(false))
     allow(view).to(receive(:increment_tab_index).and_return(1))
-    
+
     mock_service = product_tab_service_mock
     view.define_singleton_method(:product_tab_service) { mock_service }
     assign(:current_user, user)

--- a/test/controllers/instances/tabs/notes/simple_test.rb
+++ b/test/controllers/instances/tabs/notes/simple_test.rb
@@ -44,7 +44,7 @@ class InstanceTabsNotesTest < ActionController::TestCase
   end
 
   def asserts1
-    assert_select "h5", "Add Note for #{@triodia_in_brassard.name.simple_name}", 
+    assert_select "h5", "Add Note for #{@triodia_in_brassard.name.simple_name}",
       "Needs correct heading."
     assert_select "form#new_instance_note", true, "Needs insert form."
     assert_select "form#new_instance_note" do

--- a/test/controllers/loader/batch/review/period/update/end_date/not_before_start_date_test.rb
+++ b/test/controllers/loader/batch/review/period/update/end_date/not_before_start_date_test.rb
@@ -38,7 +38,7 @@ class BatchReviewPeriodUpdateEndDateNotBeforeStartDateTest < ActionController::T
                                                    "end_date(2i)"=>Date.today.month.to_s,
                                                    "end_date(1i)"=>Date.today.year.to_s
                     },
-                   "commit"=>"Save"}, 
+                   "commit"=>"Save"},
          session: { username: "fred",
                     user_full_name: "Fred Jones",
                     groups: ["batch-loader"] })

--- a/test/controllers/loader/batch/review/period/update/end_date/not_past_date_test.rb
+++ b/test/controllers/loader/batch/review/period/update/end_date/not_past_date_test.rb
@@ -38,7 +38,7 @@ class BatchReviewPeriodUpdateEndDateNotPastDateTest < ActionController::TestCase
                                                    "end_date(2i)"=>target.start_date.month.to_s,
                                                    "end_date(1i)"=>target.start_date.year.to_s,
                     },
-                   "commit"=>"Save"}, 
+                   "commit"=>"Save"},
          session: { username: "fred",
                     user_full_name: "Fred Jones",
                     groups: ["batch-loader"] })

--- a/test/controllers/loader/batch/review/period/update/end_date/partial_end_date_1_test.rb
+++ b/test/controllers/loader/batch/review/period/update/end_date/partial_end_date_1_test.rb
@@ -37,7 +37,7 @@ class BatchReviewPeriodUpdateEndDateMissingEndDayTest < ActionController::TestCa
                                                    "end_date(2i)"=>Date.today.next_week.month.to_s,
                                                    "end_date(1i)"=>Date.today.next_week.year.to_s
                     },
-                   "commit"=>"Save"}, 
+                   "commit"=>"Save"},
          session: { username: "fred",
                     user_full_name: "Fred Jones",
                     groups: ["batch-loader"] })

--- a/test/controllers/loader/batch/review/period/update/end_date/partial_end_date_2_test.rb
+++ b/test/controllers/loader/batch/review/period/update/end_date/partial_end_date_2_test.rb
@@ -37,7 +37,7 @@ class BatchReviewPeriodUpdatePartialEndDate2Test < ActionController::TestCase
                                                    "end_date(2i)"=>'',
                                                    "end_date(1i)"=>'',
                     },
-                   "commit"=>"Save"}, 
+                   "commit"=>"Save"},
          session: { username: "fred",
                     user_full_name: "Fred Jones",
                     groups: ["batch-loader"] })

--- a/test/controllers/loader/batch/review/period/update/end_date/remove_end_date_test.rb
+++ b/test/controllers/loader/batch/review/period/update/end_date/remove_end_date_test.rb
@@ -38,7 +38,7 @@ class BatchReviewPeriodUpdateEndDateRemoveTest < ActionController::TestCase
                                                    "end_date(2i)"=>'',
                                                    "end_date(1i)"=>''
                     },
-                   "commit"=>"Save"}, 
+                   "commit"=>"Save"},
          session: { username: "fred",
                     user_full_name: "Fred Jones",
                     groups: ["batch-loader"] })

--- a/test/controllers/loader/batch/review/period/update/end_date/simple_test.rb
+++ b/test/controllers/loader/batch/review/period/update/end_date/simple_test.rb
@@ -37,7 +37,7 @@ class BatchReviewPeriodUpdateEndDateSimpleTest < ActionController::TestCase
                                                    "end_date(2i)"=>Date.today.next_week.month.to_s,
                                                    "end_date(1i)"=>Date.today.next_week.year.to_s
                     },
-                   "commit"=>"Save"}, 
+                   "commit"=>"Save"},
          session: { username: "fred",
                     user_full_name: "Fred Jones",
                     groups: ["batch-loader"] })

--- a/test/controllers/loader/batch/review/period/update/start_date/not_past_date_test.rb
+++ b/test/controllers/loader/batch/review/period/update/start_date/not_past_date_test.rb
@@ -37,7 +37,7 @@ class BatchReviewPeriodUpdateStartDatePastDateNotAllowedTest < ActionController:
                                                    "end_date(2i)"=>Date.today.next_week.month.to_s,
                                                    "end_date(1i)"=>Date.today.next_week.year.to_s
                     },
-                   "commit"=>"Save"}, 
+                   "commit"=>"Save"},
          session: { username: "fred",
                     user_full_name: "Fred Jones",
                     groups: ["batch-loader"] })

--- a/test/controllers/loader/batch/review/period/update/start_date/simple_test.rb
+++ b/test/controllers/loader/batch/review/period/update/start_date/simple_test.rb
@@ -37,7 +37,7 @@ class BatchReviewPeriodUpdateStartDateSimpleTest < ActionController::TestCase
                                                    "end_date(2i)"=>Date.today.next_week.month.to_s,
                                                    "end_date(1i)"=>Date.today.next_week.year.to_s
                     },
-                   "commit"=>"Save"}, 
+                   "commit"=>"Save"},
          session: { username: "fred",
                     user_full_name: "Fred Jones",
                     groups: ["batch-loader"] })

--- a/test/controllers/loader/batch/review/period/update/unauthorised_test.rb
+++ b/test/controllers/loader/batch/review/period/update/unauthorised_test.rb
@@ -37,7 +37,7 @@ class BatchReviewPeriodUpdateUnauthorisedTest < ActionController::TestCase
                         "end_date(3i)"=>"",
                         "end_date(2i)"=>"",
                         "end_date(1i)"=>""},
-                   "commit"=>"Save"}, 
+                   "commit"=>"Save"},
          session: { username: "fred",
                     user_full_name: "Fred Jones",
                     groups: ["edit"] })

--- a/test/controllers/search/loader/names/with_invalid_default_batch_and_limit_test.rb
+++ b/test/controllers/search/loader/names/with_invalid_default_batch_and_limit_test.rb
@@ -32,10 +32,10 @@ class SearchLoaderNameInvalidDefaultBatchAndLimitTest < ActionController::TestCa
     assert_select "#search-results-summary",
                   /Please set a default batch/,
                   "Should be asked to set a default batch"
-    
+
     qs_field_value = css_select("#query-string-field[value]")
     assert_match /Hardenbergia violacea *limit: 10/, qs_field_value.to_s,
                 'Query string with limit should be retained'
-    
+
   end
 end

--- a/test/factories/reference.rb
+++ b/test/factories/reference.rb
@@ -103,6 +103,6 @@ FactoryBot.define do
     association :language
     association :author
     association :namespace
-    
+
   end
 end

--- a/test/integration/loader/name/review/comment/show_comment_tab_test.rb
+++ b/test/integration/loader/name/review/comment/show_comment_tab_test.rb
@@ -20,20 +20,20 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class LoaderNameReviewCommentShowTab < ActionController::TestCase
   tests Loader::NamesController
 
 
-  # Started GET 
+  # Started GET
   # "/nsl/editor/loader_names/52428461/tab/tab_comment/accepted
-  # ?format=js&tabIndex=undefined&take_focus=true" 
+  # ?format=js&tabIndex=undefined&take_focus=true"
   #
   #  def reviewer_id(username)
   #    reviewers.find_by(user_id: User.find_by_user_name(username)).id

--- a/test/integration/loader/name/review/comment/show_overlapping_periods_message_test.rb
+++ b/test/integration/loader/name/review/comment/show_overlapping_periods_message_test.rb
@@ -20,20 +20,20 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class LoaderNameReviewCommentShowTab < ActionController::TestCase
   tests Loader::NamesController
 
 
-  # Started GET 
+  # Started GET
   # "/nsl/editor/loader_names/52428461/tab/tab_comment/accepted
-  # ?format=js&tabIndex=undefined&take_focus=true" 
+  # ?format=js&tabIndex=undefined&take_focus=true"
   #
   #  def reviewer_id(username)
   #    reviewers.find_by(user_id: User.find_by_user_name(username)).id

--- a/test/integration/taxonomy/forms/no_role/create_draft/user_cannot_create_apc_draft_test.rb
+++ b/test/integration/taxonomy/forms/no_role/create_draft/user_cannot_create_apc_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsNoRoleUserCannotCreateAPCDraftTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/no_role/new_draft/user_cannot_open_form_test.rb
+++ b/test/integration/taxonomy/forms/no_role/new_draft/user_cannot_open_form_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePubNoRoleUserCannotOpenNewDraftFormTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/no_role/place_name/user_cannot_place_name_on_APC_draft_test.rb
+++ b/test/integration/taxonomy/forms/no_role/place_name/user_cannot_place_name_on_APC_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsNoRoleUserCannotPlaceNameOnAPCDraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/no_role/place_name/user_cannot_place_name_on_FOA_draft_test.rb
+++ b/test/integration/taxonomy/forms/no_role/place_name/user_cannot_place_name_on_FOA_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsNoRoleUserCannotPlaceNameOnFOADraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/no_role/remove_name_placement/user_cannot_remove_name_placement_of_taxon_in_APC_TV_test.rb
+++ b/test/integration/taxonomy/forms/no_role/remove_name_placement/user_cannot_remove_name_placement_of_taxon_in_APC_TV_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsNoRoleUserCannotRemoveNamePlacementOnAPCDraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/no_role/remove_name_placement/user_cannot_remove_name_placement_of_taxon_in_FOA_TV_test.rb
+++ b/test/integration/taxonomy/forms/no_role/remove_name_placement/user_cannot_remove_name_placement_of_taxon_in_FOA_TV_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsNoRoleUserCannotRemoveNamePlacementForTaxonOnFOADraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/no_role/replace_placement/user_cannot_replace_placement_for_taxon_on_APC_draft_test.rb
+++ b/test/integration/taxonomy/forms/no_role/replace_placement/user_cannot_replace_placement_for_taxon_on_APC_draft_test.rb
@@ -20,19 +20,19 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsUserWithNoRoleCannotReplacePlacementOnAPCDraftTest < ActionController::TestCase
   tests TreesController
 
 # r6editor Started PATCH "/nsl/editor/trees/612279/replace_placement" for ::1 at 2025-07-17 15:34:26 +1000 (pid:642)
 # r6editor Processing by TreesController#replace_placement as JS (pid:642)
-# Parameters: {"authenticity_token"=>"[FILTERED]", 
+# Parameters: {"authenticity_token"=>"[FILTERED]",
  #             "move_placement"=>{"element_link"=>"/tree/52410589/52410631",
  #                                "instance_id"=>"612279",
  #                                "comment"=>"Subspecies are recognised in this species in Euclid... ",

--- a/test/integration/taxonomy/forms/no_role/replace_placement/user_cannot_replace_placement_for_taxon_on_FOA_draft_test.rb
+++ b/test/integration/taxonomy/forms/no_role/replace_placement/user_cannot_replace_placement_for_taxon_on_FOA_draft_test.rb
@@ -20,19 +20,19 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsUserWithNoRoleCannotReplacePlacementOnFOADraftTest < ActionController::TestCase
   tests TreesController
 
 # r6editor Started PATCH "/nsl/editor/trees/612279/replace_placement" for ::1 at 2025-07-17 15:34:26 +1000 (pid:642)
 # r6editor Processing by TreesController#replace_placement as JS (pid:642)
-# Parameters: {"authenticity_token"=>"[FILTERED]", 
+# Parameters: {"authenticity_token"=>"[FILTERED]",
  #             "move_placement"=>{"element_link"=>"/tree/52410589/52410631",
  #                                "instance_id"=>"612279",
  #                                "comment"=>"Subspecies are recognised in this species in Euclid... ",

--- a/test/integration/taxonomy/forms/no_role/update_comment/user_cannot_update_comment_test.rb
+++ b/test/integration/taxonomy/forms/no_role/update_comment/user_cannot_update_comment_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsNoRoleUserCannotUpdateCommentOnFOADraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/no_role/update_distribution/user_cannot_update_distribution_test.rb
+++ b/test/integration/taxonomy/forms/no_role/update_distribution/user_cannot_update_distribution_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsNoRoleUserCannotUpdateDistributionOnFOADraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/no_role/update_excluded/user_cannot_update_excluded_for_taxon_in_APC_TV_test.rb
+++ b/test/integration/taxonomy/forms/no_role/update_excluded/user_cannot_update_excluded_for_taxon_in_APC_TV_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsNoRoleUserCannotUpdateExcludedForTaxonOnAPCDraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/no_role/update_excluded/user_cannot_update_excluded_for_taxon_in_FOA_TV_test.rb
+++ b/test/integration/taxonomy/forms/no_role/update_excluded/user_cannot_update_excluded_for_taxon_in_FOA_TV_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsNoRoleUserCannotUpdateExcludedForTaxonOnFOADraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/no_role/update_tree_parent/user_cannot_update_tree_parent_for_axon_in_APC_TV_test.rb
+++ b/test/integration/taxonomy/forms/no_role/update_tree_parent/user_cannot_update_tree_parent_for_axon_in_APC_TV_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsNoRoleUserCannotUpdateTreeParentForTaxonOnAPCDraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_builder/apc/place_name/user_can_place_name_on_APC_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/place_name/user_can_place_name_on_APC_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCanPlaceNameOnAPCDraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_builder/apc/place_name/user_cannot_place_name_on_FOA_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/place_name/user_cannot_place_name_on_FOA_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCannotPlaceNameOnFOADraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_builder/apc/remove_name_placement/user_can_remove_name_placement_of_taxon_in_APC_TV_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/remove_name_placement/user_can_remove_name_placement_of_taxon_in_APC_TV_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCanRemoveNamePlacementForTaxonOnAPCDraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_builder/apc/remove_name_placement/user_cannot_remove_name_placement_of_taxon_in_FOA_TV_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/remove_name_placement/user_cannot_remove_name_placement_of_taxon_in_FOA_TV_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCannotRemoveNamePlacementForTaxonOnFOADraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_builder/apc/replace_placement/user_can_replace_placement_for_taxon_on_APC_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/replace_placement/user_can_replace_placement_for_taxon_on_APC_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCanReplacePlacementOnAPCDraftTest < ActionController::TestCase
   tests TreesController
@@ -59,7 +59,7 @@ class TaxFormsTreeBuilderAPCUserCanReplacePlacementOnAPCDraftTest < ActionContro
 
 # r6editor Started PATCH "/nsl/editor/trees/612279/replace_placement" for ::1 at 2025-07-17 15:34:26 +1000 (pid:642)
 # r6editor Processing by TreesController#replace_placement as JS (pid:642)
-# Parameters: {"authenticity_token"=>"[FILTERED]", 
+# Parameters: {"authenticity_token"=>"[FILTERED]",
  #             "move_placement"=>{"element_link"=>"/tree/52410589/52410631",
  #                                "instance_id"=>"612279",
  #                                "comment"=>"Subspecies are recognised in this species in Euclid... ",

--- a/test/integration/taxonomy/forms/tree_builder/apc/replace_placement/user_cannot_replace_placement_for_taxon_on_FOA_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/replace_placement/user_cannot_replace_placement_for_taxon_on_FOA_draft_test.rb
@@ -20,19 +20,19 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCannotReplacePlacementOnFOADraftTest < ActionController::TestCase
   tests TreesController
 
 # r6editor Started PATCH "/nsl/editor/trees/612279/replace_placement" for ::1 at 2025-07-17 15:34:26 +1000 (pid:642)
 # r6editor Processing by TreesController#replace_placement as JS (pid:642)
-# Parameters: {"authenticity_token"=>"[FILTERED]", 
+# Parameters: {"authenticity_token"=>"[FILTERED]",
  #             "move_placement"=>{"element_link"=>"/tree/52410589/52410631",
  #                                "instance_id"=>"612279",
  #                                "comment"=>"Subspecies are recognised in this species in Euclid... ",

--- a/test/integration/taxonomy/forms/tree_builder/apc/update_comment/user_can_update_comment_for_APC_tree_version_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/update_comment/user_can_update_comment_for_APC_tree_version_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCanUpdateCommentOnAPCDraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_builder/apc/update_comment/user_cannot_update_comment_for_FOA_tree_version_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/update_comment/user_cannot_update_comment_for_FOA_tree_version_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCannotUpdateCommentOnFOADraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_builder/apc/update_distribution/user_can_update_distribution_for_APC_tree_version_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/update_distribution/user_can_update_distribution_for_APC_tree_version_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCanUpdateDistributionOnAPCDraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_builder/apc/update_distribution/user_cannot_update_distribution_for_FOA_tree_version_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/update_distribution/user_cannot_update_distribution_for_FOA_tree_version_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCannotUpdateDistOnFOADraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_builder/apc/update_excluded/user_can_update_excluded_for_taxon_in_APC_TV_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/update_excluded/user_can_update_excluded_for_taxon_in_APC_TV_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCanUpdateExcludedForTaxonOnAPCDraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_builder/apc/update_excluded/user_cannot_update_excluded_for_taxon_in_FOA_TV_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/update_excluded/user_cannot_update_excluded_for_taxon_in_FOA_TV_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCannotUpdateExcludedForTaxonOnFOADraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_builder/apc/update_tree_parent/user_can_update_tree_parent_for_taxon_in_APC_TV_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/update_tree_parent/user_can_update_tree_parent_for_taxon_in_APC_TV_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCanUpdateTreeParentForTaxonOnAPCDraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_builder/apc/update_tree_parent/user_cannot_update_tree_parent_for_taxon_in_FOA_TV_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/update_tree_parent/user_cannot_update_tree_parent_for_taxon_in_FOA_TV_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCannotUpdateTreeParentForTaxonOnFOADraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_builder/apc/user_cannot_create_foa_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/user_cannot_create_foa_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCannotCreateAPCDraftTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_builder/apc/user_cannot_open_form_to_edit_apc_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/user_cannot_open_form_to_edit_apc_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCannotOpenEditFormToEdAPCDraftTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_builder/apc/user_cannot_open_form_to_edit_foa_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/user_cannot_open_form_to_edit_foa_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCannotOpenEditFormToEdFoADraftTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_builder/apc/user_cannot_update_apc_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_builder/apc/user_cannot_update_apc_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderAPCUserCannotUpdateAPCDraftTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/create_draft/user_can_create_apc_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/create_draft/user_can_create_apc_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePubAPCUserCanCreateAPCDraftTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/create_draft/user_cannot_create_foa_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/create_draft/user_cannot_create_foa_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePubAPCUserCannotCreateFoADraftTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/new_draft/user_can_open_form_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/new_draft/user_can_open_form_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePubAPCNewDraftUserCanOpenFormTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/new_draft/user_offered_apc_tree_only_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/new_draft/user_offered_apc_tree_only_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePubAPCNewDraftUserOferedAPCTreeOnlyTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/place_name/user_cannot_place_name_on_APC_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/place_name/user_cannot_place_name_on_APC_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePublisherAPCUserCannotPlaceNameOnAPCDraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/place_name/user_cannot_place_name_on_FOA_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/place_name/user_cannot_place_name_on_FOA_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePublisherAPCUserCannotPlaceNameOnFOADraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/remove_name_placement/user_cannot_remove_name_placement_of_taxon_in_APC_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/remove_name_placement/user_cannot_remove_name_placement_of_taxon_in_APC_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePublisherAPCUserCannotRemoveNamePlacementForTaxonOnAPCDraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/remove_name_placement/user_cannot_remove_name_placement_of_taxon_in_FOA_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/remove_name_placement/user_cannot_remove_name_placement_of_taxon_in_FOA_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePublisherAPCUserCannotRemoveNamePlacementForTaxonOnFOADraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/replace_placement/user_cannot_replace_placement_for_taxon_on_APC_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/replace_placement/user_cannot_replace_placement_for_taxon_on_APC_draft_test.rb
@@ -20,19 +20,19 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePublisherAPCUserCannotReplacePlacementOnAPCDraftTest < ActionController::TestCase
   tests TreesController
 
 # r6editor Started PATCH "/nsl/editor/trees/612279/replace_placement" for ::1 at 2025-07-17 15:34:26 +1000 (pid:642)
 # r6editor Processing by TreesController#replace_placement as JS (pid:642)
-# Parameters: {"authenticity_token"=>"[FILTERED]", 
+# Parameters: {"authenticity_token"=>"[FILTERED]",
  #             "move_placement"=>{"element_link"=>"/tree/52410589/52410631",
  #                                "instance_id"=>"612279",
  #                                "comment"=>"Subspecies are recognised in this species in Euclid... ",

--- a/test/integration/taxonomy/forms/tree_publisher/apc/replace_placement/user_cannot_replace_placement_for_taxon_on_FOA_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/replace_placement/user_cannot_replace_placement_for_taxon_on_FOA_draft_test.rb
@@ -20,19 +20,19 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePublisherAPCUserCannotReplacePlacementOnAPCDraftTest < ActionController::TestCase
   tests TreesController
 
 # r6editor Started PATCH "/nsl/editor/trees/612279/replace_placement" for ::1 at 2025-07-17 15:34:26 +1000 (pid:642)
 # r6editor Processing by TreesController#replace_placement as JS (pid:642)
-# Parameters: {"authenticity_token"=>"[FILTERED]", 
+# Parameters: {"authenticity_token"=>"[FILTERED]",
  #             "move_placement"=>{"element_link"=>"/tree/52410589/52410631",
  #                                "instance_id"=>"612279",
  #                                "comment"=>"Subspecies are recognised in this species in Euclid... ",

--- a/test/integration/taxonomy/forms/tree_publisher/apc/update_comment/user_cannot_update_comment_for_APC_tree_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/update_comment/user_cannot_update_comment_for_APC_tree_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePublisherAPCUserCannotUpdateCommentOnAPCDraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/update_distribution/user_cannot_update_distribution_for_APC_tree_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/update_distribution/user_cannot_update_distribution_for_APC_tree_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePublisherAPCUserCannotUpdateDistributionOnAPCDraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/update_excluded/user_cannot_update_excluded_for_taxon_on_APC_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/update_excluded/user_cannot_update_excluded_for_taxon_on_APC_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreeBuilderFOAUserCannotUpdateExcludedForTaxonOnAPCDraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/update_excluded/user_cannot_update_excluded_for_taxon_on_FOA_TV_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/update_excluded/user_cannot_update_excluded_for_taxon_on_FOA_TV_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePublisherFOAUserCanUpdateExcludedForTaxonOnFOADraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/update_tree_parent/user_cannot_update_tree_parent_for_taxon_in_APC_TV_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/update_tree_parent/user_cannot_update_tree_parent_for_taxon_in_APC_TV_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePublisherAPCUserCannotUpdateTreeParentForTaxonOnAPCDraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/update_tree_parent/user_cannot_update_tree_parent_for_taxon_in_FOA_TV_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/update_tree_parent/user_cannot_update_tree_parent_for_taxon_in_FOA_TV_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePublisherAPCUserCannotUpdateTreeParentForTaxonOnFOADraftTest < ActionController::TestCase
   tests TreesController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/user_can_open_form_to_edit_apc_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/user_can_open_form_to_edit_apc_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePubAPCUserCanOpenEditFormToEdAPCDraftTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/user_can_open_form_to_publish_apc_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/user_can_open_form_to_publish_apc_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePubAPCUserCanOpenFormToPublishAPCDraftTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/user_can_publish_apc_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/user_can_publish_apc_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePubAPCUserCanPublishAPCDraftTest < ActionController::TestCase
   tests TreeVersionsController
@@ -49,7 +49,7 @@ class TaxFormsTreePubAPCUserCanPublishAPCDraftTest < ActionController::TestCase
 
   end
 
-  # Started POST "/nsl/editor/tree_versions/publish" for 
+  # Started POST "/nsl/editor/tree_versions/publish" for
   # Processing by TreeVersionsController#publish as JS (pid:15335)
   # Parameters: {"version_id"=>"51798490",
   #              "draft_log"=>"Updates resulting from Australian Plant Census List 108, p.p. (Banksia).\n",

--- a/test/integration/taxonomy/forms/tree_publisher/apc/user_can_update_apc_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/user_can_update_apc_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePubAPCUserCanUpdateAPCDraftTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/user_cannot_open_form_to_edit_foa_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/user_cannot_open_form_to_edit_foa_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePubAPCUserCannotOpenEditFormToEdFoADraftTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/user_cannot_open_form_to_publish_foa_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/user_cannot_open_form_to_publish_foa_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePubAPCUserCannotOpenFormToPublishFoADraftTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/user_cannot_publish_foa_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/user_cannot_publish_foa_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePubAPCUserCannotPublishFOADraftTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_publisher/apc/user_cannot_update_foa_draft_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/user_cannot_update_foa_draft_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePubAPCUserCannotUpdateFOADraftTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_publisher/foa/new_draft/user_can_open_form_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/foa/new_draft/user_can_open_form_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePubFOANewDraftUserCanOpenFormTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_publisher/foa/new_draft/user_offered_foa_tree_only_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/foa/new_draft/user_offered_foa_tree_only_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePubFOANewDraftUserOferedFOATreeOnlyTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/forms/tree_publisher/ron/new_draft/user_cannot_open_form_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/ron/new_draft/user_cannot_open_form_test.rb
@@ -20,12 +20,12 @@ require "test_helper"
 
 # Single search controller test.
 #
-# Note: 
+# Note:
 #   xhr: true
 #
-# stopped this error in test: 
+# stopped this error in test:
 #
-# ActionController::InvalidCrossOriginRequest: Security warning: 
+# ActionController::InvalidCrossOriginRequest: Security warning:
 #   an embedded <script> tag on another site requested protected JavaScript.
 class TaxFormsTreePubRONNewDraftUserCannotOpenFormTest < ActionController::TestCase
   tests TreeVersionsController

--- a/test/integration/taxonomy/menu/tree_builder/foa/user_cannot_unset_apc_workspace_test.rb
+++ b/test/integration/taxonomy/menu/tree_builder/foa/user_cannot_unset_apc_workspace_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 # Single search controller test.
 #
 # This is arguably a less important test - that a user cannot unset a workspace tree
-# version for tree they have no access to (what harm would happen if they could UNset it is the 
+# version for tree they have no access to (what harm would happen if they could UNset it is the
 # point) - but the test is here as part of a suite of
 # tests I'm setting up for this change in permissions.
 class TreeBuilderFoaUserCannotUnsetWorkspaceTest < ActionController::TestCase

--- a/test/integration/taxonomy/menu/tree_publisher/apc/user_has_taxonomy_menu_options_test.rb
+++ b/test/integration/taxonomy/menu/tree_publisher/apc/user_has_taxonomy_menu_options_test.rb
@@ -22,7 +22,7 @@ require "test_helper"
 class TreePublisherApcTaxoMenuOptions < ActionController::TestCase
   tests SearchController
 
-  # Assumes one APC draft tree_version 
+  # Assumes one APC draft tree_version
   test "APC tree publisher has taxonomy menu options" do
     user = users(:apc_tax_publisher)
     get(:search,

--- a/test/integration/taxonomy/menu/tree_publisher/foa/user_cannot_unset_apc_workspace_test.rb
+++ b/test/integration/taxonomy/menu/tree_publisher/foa/user_cannot_unset_apc_workspace_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 # Single search controller test.
 #
 # This is arguably a less important test - that a user cannot unset a workspace tree
-# version for tree they have no access to (what harm would happen if they could UNset it is the 
+# version for tree they have no access to (what harm would happen if they could UNset it is the
 # point) - but the test is here as part of a suite of
 # tests I'm setting up for this change in permissions.
 class TreePublisherFoaUserCannotUnsetWorkspaceTest < ActionController::TestCase

--- a/test/integration/taxonomy/reports/tab/apc/tree_builder/changes_tab/apc_tree_builder_cannot_run_changes_report_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_builder/changes_tab/apc_tree_builder_cannot_run_changes_report_for_FOA_draft_test.rb
@@ -24,7 +24,7 @@ class APCTreeBuilderCannotRunChangesReportForFOADraftTest < ActionController::Te
   def setup
   end
 
-  # r6editor Started GET "/nsl/editor/trees/run/diff" 
+  # r6editor Started GET "/nsl/editor/trees/run/diff"
   # r6editor Processing by TreesController#run_diff as JS
   test "APC tree builder cannot run changes report for FOA draft" do
     user = users(:apc_tax_builder)

--- a/test/integration/taxonomy/reports/tab/apc/tree_builder/changes_tab/apc_tree_builder_cannot_show_changes_tab_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_builder/changes_tab/apc_tree_builder_cannot_show_changes_tab_for_FOA_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class APCTreeBuilderCannotShowChangesTabForFOADraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/diff" 
+  # r6editor Started GET "/nsl/editor/trees/show/diff"
   # r6editor Processing by TreesController#show_diff as JS
   test "APC tree builder cannot show changes tab for FOA draft" do
     user = users(:apc_tax_builder)

--- a/test/integration/taxonomy/reports/tab/apc/tree_builder/changes_tab/apc_tree_builder_run_changes_report_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_builder/changes_tab/apc_tree_builder_run_changes_report_for_APC_draft_test.rb
@@ -35,7 +35,7 @@ class APCTreeBuilderRunChangesReportForAPCDraftTest < ActionController::TestCase
       to_return(status: 200, body: "", headers: {})
   end
 
-  # r6editor Started GET "/nsl/editor/trees/run/diff" 
+  # r6editor Started GET "/nsl/editor/trees/run/diff"
   # r6editor Processing by TreesController#run_diff as JS
   test "APC tree builder can run changes report for APC draft" do
     user = users(:apc_tax_builder)

--- a/test/integration/taxonomy/reports/tab/apc/tree_builder/changes_tab/apc_tree_builder_show_changes_tab_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_builder/changes_tab/apc_tree_builder_show_changes_tab_for_APC_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class APCTreeBuilderCanShowChangesTabForAPCDraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/cas" 
+  # r6editor Started GET "/nsl/editor/trees/show/cas"
   # r6editor Processing by TreesController#show_cas as JS
   test "APC tree builder can show changes tab for APC draft" do
     user = users(:apc_tax_builder)

--- a/test/integration/taxonomy/reports/tab/apc/tree_builder/synonymy_tab/apc_tree_builder_can_run_synonymy_report_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_builder/synonymy_tab/apc_tree_builder_can_run_synonymy_report_for_APC_draft_test.rb
@@ -34,7 +34,7 @@ class APCTreeBuilderCanRunSynonymyReportForAPCDraftTest < ActionController::Test
     to_return(status: 200, body: "", headers: {})
   end
 
-  # r6editor Started GET "/nsl/editor/trees/run/cas" 
+  # r6editor Started GET "/nsl/editor/trees/run/cas"
   # r6editor Processing by TreesController#run_cas as JS
   test "APC tree builder can run syn report for APC draft" do
     user = users(:apc_tax_builder)

--- a/test/integration/taxonomy/reports/tab/apc/tree_builder/synonymy_tab/apc_tree_builder_can_show_synonymy_tab_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_builder/synonymy_tab/apc_tree_builder_can_show_synonymy_tab_for_APC_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class APCTreeBuilderCanShowSynonymyTabForAPCDraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/cas" 
+  # r6editor Started GET "/nsl/editor/trees/show/cas"
   # r6editor Processing by TreesController#show_cas as JS
   test "APC tree builder can show syn tab for APC draft" do
     user = users(:apc_tax_builder)

--- a/test/integration/taxonomy/reports/tab/apc/tree_builder/synonymy_tab/apc_tree_builder_cannot_run_synonymy_report_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_builder/synonymy_tab/apc_tree_builder_cannot_run_synonymy_report_for_FOA_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class APCTreeBuilderCannotRunSynonymyTabForFOADraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/run/cas" 
+  # r6editor Started GET "/nsl/editor/trees/run/cas"
   # r6editor Processing by TreesController#run_cas as JS
   test "APC tree builder cannot run syn report for FOA draft" do
     user = users(:apc_tax_builder)

--- a/test/integration/taxonomy/reports/tab/apc/tree_builder/synonymy_tab/apc_tree_builder_cannot_show_synonymy_tab_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_builder/synonymy_tab/apc_tree_builder_cannot_show_synonymy_tab_for_FOA_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class APCTreeBuilderCannotShowSynonymyTabForFOADraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/cas" 
+  # r6editor Started GET "/nsl/editor/trees/show/cas"
   # r6editor Processing by TreesController#show_cas as JS
   test "APC tree builder cannot show syn tab for FOA draft" do
     user = users(:apc_tax_builder)

--- a/test/integration/taxonomy/reports/tab/apc/tree_builder/synonymy_tab/update_synonymy_by_instance/apc_tree_builder_update_syn_by_instance_for_apc_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_builder/synonymy_tab/update_synonymy_by_instance/apc_tree_builder_update_syn_by_instance_for_apc_draft_test.rb
@@ -34,7 +34,7 @@ class APCTreeBuilderUpdateSynByInstanceForAPCDraftTest < ActionController::TestC
     to_return(status: 200, body: "", headers: {})
   end
 
-  # r6editor Started POST "/nsl/editor/trees/update_synonymy_by_instance" 
+  # r6editor Started POST "/nsl/editor/trees/update_synonymy_by_instance"
   # r6editor Processing by TreesController #update_synonymy_by_instance as JS
   # r6editor Parameters: {"versionId"=>"52410589", "instances"=>"612279", "update_checked_synonymy"=>""}
   test "APC tree builder can update synonymy by instance for APC draft" do

--- a/test/integration/taxonomy/reports/tab/apc/tree_builder/synonymy_tab/update_synonymy_by_instance/apc_tree_builder_update_syn_by_instance_for_foa_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_builder/synonymy_tab/update_synonymy_by_instance/apc_tree_builder_update_syn_by_instance_for_foa_draft_test.rb
@@ -34,7 +34,7 @@ class APCTreeBuilderUpdateSynByInstanceForFOADraftTest < ActionController::TestC
     to_return(status: 200, body: "", headers: {})
   end
 
-  # r6editor Started POST "/nsl/editor/trees/update_synonymy_by_instance" 
+  # r6editor Started POST "/nsl/editor/trees/update_synonymy_by_instance"
   # r6editor Processing by TreesController #update_synonymy_by_instance as JS
   # r6editor Parameters: {"versionId"=>"52410589", "instances"=>"612279", "update_checked_synonymy"=>""}
   test "APC tree builder can update synonymy by instance for FOA draft" do

--- a/test/integration/taxonomy/reports/tab/apc/tree_builder/validation_tab/apc_tree_builder_can_run_validation_report_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_builder/validation_tab/apc_tree_builder_can_run_validation_report_for_APC_draft_test.rb
@@ -34,7 +34,7 @@ class APCTreeBuilderCanRunValidationReportForAPCDraftTest < ActionController::Te
     to_return(status: 200, body: "", headers: {})
   end
 
-  # r6editor Started GET "/nsl/editor/trees/run/valrep" 
+  # r6editor Started GET "/nsl/editor/trees/run/valrep"
   # r6editor Processing by TreesController#run_valrep as JS
   test "APC tree builder can run validation report for APC draft" do
     user = users(:apc_tax_builder)

--- a/test/integration/taxonomy/reports/tab/apc/tree_builder/validation_tab/apc_tree_builder_can_show_validation_tab_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_builder/validation_tab/apc_tree_builder_can_show_validation_tab_for_APC_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class APCTreeBuilderCanShowValidationTabForAPCDraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/valrep" 
+  # r6editor Started GET "/nsl/editor/trees/show/valrep"
   # r6editor Processing by TreesController#show_valrep as JS
   test "APC tree builder can show validation tab for APC draft" do
     user = users(:apc_tax_builder)

--- a/test/integration/taxonomy/reports/tab/apc/tree_builder/validation_tab/apc_tree_builder_cannot_run_validation_report_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_builder/validation_tab/apc_tree_builder_cannot_run_validation_report_for_FOA_draft_test.rb
@@ -24,7 +24,7 @@ class APCTreeBuilderCannotRunValidationReportForFOADraftTest < ActionController:
   def setup
   end
 
-  # r6editor Started GET "/nsl/editor/trees/run/valrep" 
+  # r6editor Started GET "/nsl/editor/trees/run/valrep"
   # r6editor Processing by TreesController#run_valrep as JS
   test "APC tree builder cannot run validation report for FOA draft" do
     user = users(:apc_tax_builder)

--- a/test/integration/taxonomy/reports/tab/apc/tree_builder/validation_tab/apc_tree_builder_cannot_show_validation_tab_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_builder/validation_tab/apc_tree_builder_cannot_show_validation_tab_for_FOA_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class APCTreeBuilderCannotShowValidationTabForFOADraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/valrep" 
+  # r6editor Started GET "/nsl/editor/trees/show/valrep"
   # r6editor Processing by TreesController#show_valrep as JS
   test "APC tree builder cannot show validation tab for FOA draft" do
     user = users(:apc_tax_builder)

--- a/test/integration/taxonomy/reports/tab/apc/tree_publisher/changes_tab/apc_tree_publisher_run_changes_report_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_publisher/changes_tab/apc_tree_publisher_run_changes_report_for_APC_draft_test.rb
@@ -34,7 +34,7 @@ class APCTreePublisherRunChangesReportForAPCDraftTest < ActionController::TestCa
       to_return(status: 200, body: "", headers: {})
   end
 
-  # r6editor Started GET "/nsl/editor/trees/run/diff" 
+  # r6editor Started GET "/nsl/editor/trees/run/diff"
   # r6editor Processing by TreesController#run_diff as JS
   test "APC tree publisher can run changes report for APC draft" do
     user = users(:apc_tax_publisher)

--- a/test/integration/taxonomy/reports/tab/apc/tree_publisher/changes_tab/apc_tree_publisher_run_changes_report_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_publisher/changes_tab/apc_tree_publisher_run_changes_report_for_FOA_draft_test.rb
@@ -24,7 +24,7 @@ class APCTreePublisherRunChangesReportForFOADraftTest < ActionController::TestCa
   def setup
   end
 
-  # r6editor Started GET "/nsl/editor/trees/run/diff" 
+  # r6editor Started GET "/nsl/editor/trees/run/diff"
   # r6editor Processing by TreesController#run_diff as JS
   test "APC tree publisher run changes report for FOA draft" do
     user = users(:apc_tax_publisher)

--- a/test/integration/taxonomy/reports/tab/apc/tree_publisher/changes_tab/apc_tree_publisher_show_changes_tab_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_publisher/changes_tab/apc_tree_publisher_show_changes_tab_for_APC_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class APCTreePublisherShowChangesTabForAPCDraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/cas" 
+  # r6editor Started GET "/nsl/editor/trees/show/cas"
   # r6editor Processing by TreesController#show_cas as JS
   test "APC tree publisher show changes tab for APC draft" do
     user = users(:apc_tax_publisher)

--- a/test/integration/taxonomy/reports/tab/apc/tree_publisher/changes_tab/apc_tree_publisher_show_changes_tab_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_publisher/changes_tab/apc_tree_publisher_show_changes_tab_for_FOA_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class APCTreePublisherShowChangesTabForFOADraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/diff" 
+  # r6editor Started GET "/nsl/editor/trees/show/diff"
   # r6editor Processing by TreesController#show_diff as JS
   test "APC tree publisher show changes tab for FOA draft" do
     user = users(:apc_tax_publisher)

--- a/test/integration/taxonomy/reports/tab/apc/tree_publisher/synonymy_tab/apc_tree_publisher_run_synonymy_report_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_publisher/synonymy_tab/apc_tree_publisher_run_synonymy_report_for_APC_draft_test.rb
@@ -34,7 +34,7 @@ class APCTreePublisherRunSynonymyReportForAPCDraftTest < ActionController::TestC
     to_return(status: 200, body: "", headers: {})
   end
 
-  # r6editor Started GET "/nsl/editor/trees/run/cas" 
+  # r6editor Started GET "/nsl/editor/trees/run/cas"
   # r6editor Processing by TreesController#run_cas as JS
   test "APC tree publisher can run syn report for APC draft" do
     user = users(:apc_tax_publisher)

--- a/test/integration/taxonomy/reports/tab/apc/tree_publisher/synonymy_tab/apc_tree_publisher_run_synonymy_report_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_publisher/synonymy_tab/apc_tree_publisher_run_synonymy_report_for_FOA_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class APCTreePublisherRunSynonymyTabForFOADraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/run/cas" 
+  # r6editor Started GET "/nsl/editor/trees/run/cas"
   # r6editor Processing by TreesController#run_cas as JS
   test "APC tree publisher cannot run syn report for FOA draft" do
     user = users(:apc_tax_publisher)

--- a/test/integration/taxonomy/reports/tab/apc/tree_publisher/synonymy_tab/apc_tree_publisher_show_synonymy_tab_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_publisher/synonymy_tab/apc_tree_publisher_show_synonymy_tab_for_APC_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class APCTreePublisherShowSynonymyTabForAPCDraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/cas" 
+  # r6editor Started GET "/nsl/editor/trees/show/cas"
   # r6editor Processing by TreesController#show_cas as JS
   test "APC tree publisher can show syn tab for APC draft" do
     user = users(:apc_tax_publisher)

--- a/test/integration/taxonomy/reports/tab/apc/tree_publisher/synonymy_tab/apc_tree_publisher_show_synonymy_tab_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_publisher/synonymy_tab/apc_tree_publisher_show_synonymy_tab_for_FOA_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class APCTreePublisherShowSynonymyTabForFOADraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/cas" 
+  # r6editor Started GET "/nsl/editor/trees/show/cas"
   # r6editor Processing by TreesController#show_cas as JS
   test "APC tree publisher cannot show syn tab for FOA draft" do
     user = users(:apc_tax_publisher)

--- a/test/integration/taxonomy/reports/tab/apc/tree_publisher/synonymy_tab/update_synonymy_by_instance/apc_tree_publisher_update_syn_by_instance_for_apc_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_publisher/synonymy_tab/update_synonymy_by_instance/apc_tree_publisher_update_syn_by_instance_for_apc_draft_test.rb
@@ -34,7 +34,7 @@ class APCTreePublisherUpdateSynByInstanceForAPCDraftTest < ActionController::Tes
   to_return(status: 200, body: "", headers: {})
   end
 
-  # r6editor Started POST "/nsl/editor/trees/update_synonymy_by_instance" 
+  # r6editor Started POST "/nsl/editor/trees/update_synonymy_by_instance"
   # r6editor Processing by TreesController #update_synonymy_by_instance as JS
   # r6editor Parameters: {"versionId"=>"52410589", "instances"=>"612279", "update_checked_synonymy"=>""}
   test "APC tree publisher can update synonymy by instance for APC draft" do

--- a/test/integration/taxonomy/reports/tab/apc/tree_publisher/synonymy_tab/update_synonymy_by_instance/apc_tree_publisher_update_syn_by_instance_for_foa_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_publisher/synonymy_tab/update_synonymy_by_instance/apc_tree_publisher_update_syn_by_instance_for_foa_draft_test.rb
@@ -34,7 +34,7 @@ class APCTreePublisherUpdateSynByInstanceForFOADraftTest < ActionController::Tes
     to_return(status: 200, body: "", headers: {})
   end
 
-  # r6editor Started POST "/nsl/editor/trees/update_synonymy_by_instance" 
+  # r6editor Started POST "/nsl/editor/trees/update_synonymy_by_instance"
   # r6editor Processing by TreesController #update_synonymy_by_instance as JS
   # r6editor Parameters: {"versionId"=>"52410589", "instances"=>"612279", "update_checked_synonymy"=>""}
   test "APC tree publisher can update synonymy by instance for FOA draft" do

--- a/test/integration/taxonomy/reports/tab/apc/tree_publisher/validation_tab/apc_tree_publisher_run_validation_report_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_publisher/validation_tab/apc_tree_publisher_run_validation_report_for_APC_draft_test.rb
@@ -34,7 +34,7 @@ class APCTreePublisherRunValidationReportForAPCDraftTest < ActionController::Tes
     to_return(status: 200, body: "", headers: {})
   end
 
-  # r6editor Started GET "/nsl/editor/trees/run/valrep" 
+  # r6editor Started GET "/nsl/editor/trees/run/valrep"
   # r6editor Processing by TreesController#run_valrep as JS
   test "APC tree publisher can run validation report for APC draft" do
     user = users(:apc_tax_publisher)

--- a/test/integration/taxonomy/reports/tab/apc/tree_publisher/validation_tab/apc_tree_publisher_run_validation_report_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_publisher/validation_tab/apc_tree_publisher_run_validation_report_for_FOA_draft_test.rb
@@ -24,7 +24,7 @@ class APCTreePublisherRunValidationReportForFOADraftTest < ActionController::Tes
   def setup
   end
 
-  # r6editor Started GET "/nsl/editor/trees/run/valrep" 
+  # r6editor Started GET "/nsl/editor/trees/run/valrep"
   # r6editor Processing by TreesController#run_valrep as JS
   test "APC tree publisher cannot run validation report for FOA draft" do
     user = users(:apc_tax_publisher)

--- a/test/integration/taxonomy/reports/tab/apc/tree_publisher/validation_tab/apc_tree_publisher_show_validation_tab_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_publisher/validation_tab/apc_tree_publisher_show_validation_tab_for_APC_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class APCTreePublisherShowValidationTabForAPCDraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/valrep" 
+  # r6editor Started GET "/nsl/editor/trees/show/valrep"
   # r6editor Processing by TreesController#show_valrep as JS
   test "APC tree publisher can show validation tab for APC draft" do
     user = users(:apc_tax_publisher)

--- a/test/integration/taxonomy/reports/tab/apc/tree_publisher/validation_tab/apc_tree_publisher_show_validation_tab_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/apc/tree_publisher/validation_tab/apc_tree_publisher_show_validation_tab_for_FOA_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class APCTreePublisherShowValidationTabForFOADraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/valrep" 
+  # r6editor Started GET "/nsl/editor/trees/show/valrep"
   # r6editor Processing by TreesController#show_valrep as JS
   test "APC tree publisher cannot show validation tab for FOA draft" do
     user = users(:apc_tax_publisher)

--- a/test/integration/taxonomy/reports/tab/no_role_user/changes_tab/no_role_user_cannot_run_changes_report_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/no_role_user/changes_tab/no_role_user_cannot_run_changes_report_for_APC_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class NoRoleUserCanRunChangesReportForAPCDraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/run/diff" 
+  # r6editor Started GET "/nsl/editor/trees/run/diff"
   # r6editor Processing by TreesController#run_diff as JS
   test "user with no role cannot run changes report for APC draft" do
     user = users(:no_role)

--- a/test/integration/taxonomy/reports/tab/no_role_user/changes_tab/no_role_user_cannot_run_changes_report_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/no_role_user/changes_tab/no_role_user_cannot_run_changes_report_for_FOA_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class NoRoleUserCannotRunChangesReportForFOADraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/run/diff" 
+  # r6editor Started GET "/nsl/editor/trees/run/diff"
   # r6editor Processing by TreesController#run_diff as JS
   test "user with no role cannot run changes report for FOA draft" do
     user = users(:no_role)

--- a/test/integration/taxonomy/reports/tab/no_role_user/changes_tab/no_role_user_cannot_show_changes_tab_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/no_role_user/changes_tab/no_role_user_cannot_show_changes_tab_for_APC_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class NoRoleUserCannotShowChangesTabForAPCDraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/cas" 
+  # r6editor Started GET "/nsl/editor/trees/show/cas"
   # r6editor Processing by TreesController#show_cas as JS
   test "user with no role cannot show changes tab for APC draft" do
     user = users(:no_role)

--- a/test/integration/taxonomy/reports/tab/no_role_user/changes_tab/no_role_user_cannot_show_changes_tab_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/no_role_user/changes_tab/no_role_user_cannot_show_changes_tab_for_FOA_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class NoRoleUserCannotShowChangesTabForFOADraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/diff" 
+  # r6editor Started GET "/nsl/editor/trees/show/diff"
   # r6editor Processing by TreesController#show_diff as JS
   test "user with no role cannot show changes tab for FOA draft" do
     user = users(:no_role)

--- a/test/integration/taxonomy/reports/tab/no_role_user/synonymy_tab/no_role_user_cannot_run_synonymy_report_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/no_role_user/synonymy_tab/no_role_user_cannot_run_synonymy_report_for_APC_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class NoRoleUserCanRunSynonymyReportForAPCDraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/run/cas" 
+  # r6editor Started GET "/nsl/editor/trees/run/cas"
   # r6editor Processing by TreesController#run_cas as JS
   test "user with no role cannot run syn report for APC draft" do
     user = users(:no_role)

--- a/test/integration/taxonomy/reports/tab/no_role_user/synonymy_tab/no_role_user_cannot_run_synonymy_report_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/no_role_user/synonymy_tab/no_role_user_cannot_run_synonymy_report_for_FOA_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class NoRoleUserCannotRunSynonymyTabForFOADraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/run/cas" 
+  # r6editor Started GET "/nsl/editor/trees/run/cas"
   # r6editor Processing by TreesController#run_cas as JS
   test "user with no role cannot run syn report for FOA draft" do
     user = users(:no_role)

--- a/test/integration/taxonomy/reports/tab/no_role_user/synonymy_tab/no_role_user_cannot_show_synonymy_tab_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/no_role_user/synonymy_tab/no_role_user_cannot_show_synonymy_tab_for_APC_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class NoRoleUserCanShowSynonymyTabForAPCDraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/cas" 
+  # r6editor Started GET "/nsl/editor/trees/show/cas"
   # r6editor Processing by TreesController#show_cas as JS
   test "user with no role cannot show syn tab for APC draft" do
     user = users(:no_role)

--- a/test/integration/taxonomy/reports/tab/no_role_user/synonymy_tab/no_role_user_cannot_show_synonymy_tab_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/no_role_user/synonymy_tab/no_role_user_cannot_show_synonymy_tab_for_FOA_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class NoRoleUserCannotShowSynonymyTabForFOADraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/cas" 
+  # r6editor Started GET "/nsl/editor/trees/show/cas"
   # r6editor Processing by TreesController#show_cas as JS
   test "user with no role cannot show syn tab for FOA draft" do
     user = users(:no_role)

--- a/test/integration/taxonomy/reports/tab/no_role_user/synonymy_tab/update_synonymy_by_instance/no_role_user_cannot_update_syn_by_instance_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/no_role_user/synonymy_tab/update_synonymy_by_instance/no_role_user_cannot_update_syn_by_instance_for_APC_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class NoRoleUserUpdateSynByInstanceForAPCDraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started POST "/nsl/editor/trees/update_synonymy_by_instance" 
+  # r6editor Started POST "/nsl/editor/trees/update_synonymy_by_instance"
   # r6editor Processing by TreesController #update_synonymy_by_instance as JS
   # r6editor Parameters: {"versionId"=>"52410589", "instances"=>"612279", "update_checked_synonymy"=>""}
   test "user with no role cannot update synonymy by instance for APC draft" do

--- a/test/integration/taxonomy/reports/tab/no_role_user/synonymy_tab/update_synonymy_by_instance/no_role_user_cannot_update_syn_by_instance_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/no_role_user/synonymy_tab/update_synonymy_by_instance/no_role_user_cannot_update_syn_by_instance_for_FOA_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class NoRoleUserUpdateSynByInstanceForFOADraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started POST "/nsl/editor/trees/update_synonymy_by_instance" 
+  # r6editor Started POST "/nsl/editor/trees/update_synonymy_by_instance"
   # r6editor Processing by TreesController #update_synonymy_by_instance as JS
   # r6editor Parameters: {"versionId"=>"52410589", "instances"=>"612279", "update_checked_synonymy"=>""}
   test "user with no role cannot update synonymy by instance for FOA draft" do

--- a/test/integration/taxonomy/reports/tab/no_role_user/validation_tab/no_role_user_cannot_run_validation_report_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/no_role_user/validation_tab/no_role_user_cannot_run_validation_report_for_APC_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class NoRoleUserCannotRunValidationReportForAPCDraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/run/valrep" 
+  # r6editor Started GET "/nsl/editor/trees/run/valrep"
   # r6editor Processing by TreesController#run_valrep as JS
   test "user with no role cannot run validation report for APC draft" do
     user = users(:no_role)

--- a/test/integration/taxonomy/reports/tab/no_role_user/validation_tab/no_role_user_cannot_run_validation_report_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/no_role_user/validation_tab/no_role_user_cannot_run_validation_report_for_FOA_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class NoRoleUserCannotRunValidationReportForFOADraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/run/valrep" 
+  # r6editor Started GET "/nsl/editor/trees/run/valrep"
   # r6editor Processing by TreesController#run_valrep as JS
   test "user with no role cannot run validation report for FOA draft" do
     user = users(:no_role)

--- a/test/integration/taxonomy/reports/tab/no_role_user/validation_tab/no_role_user_cannot_show_validation_tab_for_APC_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/no_role_user/validation_tab/no_role_user_cannot_show_validation_tab_for_APC_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class NoRoleUserCanShowValidationTabForAPCDraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/valrep" 
+  # r6editor Started GET "/nsl/editor/trees/show/valrep"
   # r6editor Processing by TreesController#show_valrep as JS
   test "user with no role cannot show validation tab for APC draft" do
     user = users(:no_role)

--- a/test/integration/taxonomy/reports/tab/no_role_user/validation_tab/no_role_user_cannot_show_validation_tab_for_FOA_draft_test.rb
+++ b/test/integration/taxonomy/reports/tab/no_role_user/validation_tab/no_role_user_cannot_show_validation_tab_for_FOA_draft_test.rb
@@ -21,7 +21,7 @@ require "test_helper"
 class NoRoleUserCannotShowValidationTabForFOADraftTest < ActionController::TestCase
   tests TreesController
 
-  # r6editor Started GET "/nsl/editor/trees/show/valrep" 
+  # r6editor Started GET "/nsl/editor/trees/show/valrep"
   # r6editor Processing by TreesController#show_valrep as JS
   test "user with no role cannot show validation tab for FOA draft" do
     user = users(:no_role)

--- a/test/models/author/validations/length/abbrev_too_long_test.rb
+++ b/test/models/author/validations/length/abbrev_too_long_test.rb
@@ -28,7 +28,7 @@ class AuthorAbbrevTooLongTest < ActiveSupport::TestCase
   test "author abbrev too long test" do
     author = authors(:joe)
     assert author.valid?, "Author should be valid to start"
-    author.abbrev = "X" * @max 
+    author.abbrev = "X" * @max
     assert author.valid?, "Author should be valid with abbrev #{@max} chars long"
     assert author.save!, "Author should save"
     author.abbrev = "X" * (@max + 1)

--- a/test/models/author/validations/length/extra_information_too_long_test.rb
+++ b/test/models/author/validations/length/extra_information_too_long_test.rb
@@ -28,7 +28,7 @@ class AuthorExtraInformationTooLongTest < ActiveSupport::TestCase
   test "author extra information too long test" do
     author = authors(:joe)
     assert author.valid?, "Author should be valid to start"
-    author.extra_information = "X" * @max 
+    author.extra_information = "X" * @max
     assert author.valid?, "Author should be valid with extra information #{@max} chars long"
     assert author.save!, "Author should save"
     author.extra_information = "X" * (@max + 1)

--- a/test/models/author/validations/length/name_too_long_test.rb
+++ b/test/models/author/validations/length/name_too_long_test.rb
@@ -28,7 +28,7 @@ class AuthorNameTooLongTest < ActiveSupport::TestCase
   test "author name too long test" do
     author = authors(:joe)
     assert author.valid?, "Author should be valid to start"
-    author.name = "X" * @max 
+    author.name = "X" * @max
     assert author.valid?, "Author should be valid with name #{@max} chars long"
     assert author.save!, "Author should save"
     author.name = "X" * (@max + 1)

--- a/test/models/author/validations/length/notes_too_long_test.rb
+++ b/test/models/author/validations/length/notes_too_long_test.rb
@@ -28,7 +28,7 @@ class AuthorNotesTooLongTest < ActiveSupport::TestCase
   test "author notes too long test" do
     author = authors(:joe)
     assert author.valid?, "Author should be valid to start"
-    author.notes = "X" * @max 
+    author.notes = "X" * @max
     assert author.valid?, "Author should be valid with notes #{@max} chars long"
     assert author.save!, "Author should save"
     author.notes = "X" * (@max + 1)

--- a/test/models/instance/as_typeahead/for_synonymy/rank_restrictions/infrafamily/familia_test.rb
+++ b/test/models/instance/as_typeahead/for_synonymy/rank_restrictions/infrafamily/familia_test.rb
@@ -44,7 +44,7 @@ class TypeaheadForSynonymyFamiliaTest < ActiveSupport::TestCase
              "Expect no #{rank_string} to be suggested"
     end
   end
-  
+
   def check_inclusions
     %w(Subfamilia Tribus Subtribus
        [unranked]).each do |rank_string|

--- a/test/models/instance/as_typeahead/for_synonymy/rank_restrictions/infrafamily/subfamilia_test.rb
+++ b/test/models/instance/as_typeahead/for_synonymy/rank_restrictions/infrafamily/subfamilia_test.rb
@@ -44,7 +44,7 @@ class TypeaheadForSynonymySubfamiliaTest < ActiveSupport::TestCase
              "Expect no #{rank_string} to be suggested"
     end
   end
-  
+
   def check_inclusions
     %w(Familia Tribus Subtribus
        [unranked]).each do |rank_string|

--- a/test/models/instance/as_typeahead/for_synonymy/rank_restrictions/infrafamily/subtribus_test.rb
+++ b/test/models/instance/as_typeahead/for_synonymy/rank_restrictions/infrafamily/subtribus_test.rb
@@ -44,7 +44,7 @@ class TypeaheadForSynonymySubtribusTest < ActiveSupport::TestCase
              "Expect no #{rank_string} to be suggested"
     end
   end
-  
+
   def check_inclusions
     %w(Familia Subfamilia Tribus
        [unranked]).each do |rank_string|

--- a/test/models/instance/as_typeahead/for_synonymy/rank_restrictions/infrafamily/tribus_test.rb
+++ b/test/models/instance/as_typeahead/for_synonymy/rank_restrictions/infrafamily/tribus_test.rb
@@ -44,9 +44,9 @@ class TypeaheadForSynonymyTribusTest < ActiveSupport::TestCase
              "Expect no #{rank_string} to be suggested"
     end
   end
-  
+
   def check_inclusions
-    %w(Familia Subfamilia Subtribus 
+    %w(Familia Subfamilia Subtribus
        [unranked]).each do |rank_string|
       escape_s = Regexp.escape(rank_string)
       assert @rank_names.select { |e| e.match(/\A#{escape_s}\z/) }.size >= 1,

--- a/test/models/instance/as_typeahead/for_synonymy/rank_restrictions/infragenus/series_test.rb
+++ b/test/models/instance/as_typeahead/for_synonymy/rank_restrictions/infragenus/series_test.rb
@@ -47,7 +47,7 @@ class TypeaheadForSynonymySeriesTest < ActiveSupport::TestCase
   def check_infrageneric_inclusions
     assert @rank_names.select { |e| e == "Genus" }.size >= 4,
            "Expect correct number of genera to be suggested"
-    %w(Subgenus Sectio Subsectio 
+    %w(Subgenus Sectio Subsectio
        Subseries Superspecies [infragenus] [unranked]).each do |rank_string|
       escaped_s = Regexp.escape(rank_string)
       assert @rank_names.select { |e| e.match(/\A#{escaped_s}\z/) }.size >= 1,

--- a/test/models/instance/as_typeahead/for_synonymy/rank_restrictions/infragenus/subsectio_test.rb
+++ b/test/models/instance/as_typeahead/for_synonymy/rank_restrictions/infragenus/subsectio_test.rb
@@ -47,7 +47,7 @@ class TypeaheadForSynonymySubsectioTest < ActiveSupport::TestCase
   def check_infrageneric_inclusions
     assert @rank_names.select { |e| e == "Genus" }.size >= 4,
            "Expect correct number of genera to be suggested"
-    %w(Sectio Series Subgenus 
+    %w(Sectio Series Subgenus
        Subseries Superspecies [infragenus] [unranked]).each do |rank_string|
       escaped_s = Regexp.escape(rank_string)
       assert @rank_names.select { |e| e.match(/\A#{escaped_s}\z/) }.size >= 1,

--- a/test/models/instance/as_typeahead/for_synonymy/rank_restrictions/infragenus/subseries_test.rb
+++ b/test/models/instance/as_typeahead/for_synonymy/rank_restrictions/infragenus/subseries_test.rb
@@ -47,7 +47,7 @@ class TypeaheadForSynonymySubseriesTest < ActiveSupport::TestCase
   def check_infrageneric_inclusions
     assert @rank_names.select { |e| e == "Genus" }.size >= 4,
            "Expect correct number of genera to be suggested"
-    %w(Sectio Series Subgenus Subsectio 
+    %w(Sectio Series Subgenus Subsectio
        Superspecies [infragenus] [unranked]).each do |rank_string|
       escaped_s = Regexp.escape(rank_string)
       assert @rank_names.select { |e| e.match(/\A#{escaped_s}\z/) }.size >= 1,

--- a/test/models/instance/as_typeahead/for_synonymy/rank_restrictions/infragenus/superspecies_test.rb
+++ b/test/models/instance/as_typeahead/for_synonymy/rank_restrictions/infragenus/superspecies_test.rb
@@ -47,7 +47,7 @@ class TypeaheadForSynonymySuperspeciesTest < ActiveSupport::TestCase
   def check_infrageneric_inclusions
     assert @rank_names.select { |e| e == "Genus" }.size >= 4,
            "Expect correct number of genera to be suggested"
-    %w(Sectio Series Subgenus Subsectio Subseries  
+    %w(Sectio Series Subgenus Subsectio Subseries
        [infragenus] [unranked]).each do |rank_string|
       escaped_s = Regexp.escape(rank_string)
       assert @rank_names.select { |e| e.match(/\A#{escaped_s}\z/) }.size >= 1,

--- a/test/models/loader/name/distribution/duplicate_regions_are_rejected_test.rb
+++ b/test/models/loader/name/distribution/duplicate_regions_are_rejected_test.rb
@@ -12,7 +12,7 @@ class DuplicateRegionsAreRejectedTest < ActiveSupport::TestCase
   end
 
   test "Duplicate regions are rejected" do
-    dv = Loader::Name::DistributionValidator.new(@dist_s, @allowed_regions) 
+    dv = Loader::Name::DistributionValidator.new(@dist_s, @allowed_regions)
     assert_not(dv.validate, "Should not validate")
     assert_equal(dv.error, @expected_error, "Error should be #{@expected_error}")
   end

--- a/test/models/loader/name/distribution/empty_distribution_is_allowed_test.rb
+++ b/test/models/loader/name/distribution/empty_distribution_is_allowed_test.rb
@@ -11,7 +11,7 @@ class EmptyDistributionIsAllowedTest < ActiveSupport::TestCase
   end
 
   test "Empty distribution is allowed" do
-    dv = Loader::Name::DistributionValidator.new(@dist_s, @allowed_regions) 
+    dv = Loader::Name::DistributionValidator.new(@dist_s, @allowed_regions)
     assert(dv.validate, "Should validate")
     assert_nil(dv.error, "Should be no error")
   end

--- a/test/models/loader/name/distribution/extra_commas_are_rejected_test.rb
+++ b/test/models/loader/name/distribution/extra_commas_are_rejected_test.rb
@@ -12,7 +12,7 @@ class DuplicateRegionsAreRejectedTest < ActiveSupport::TestCase
   end
 
   test "Extra commas are rejected" do
-    dv = Loader::Name::DistributionValidator.new(@dist_s, @allowed_regions) 
+    dv = Loader::Name::DistributionValidator.new(@dist_s, @allowed_regions)
     assert_not(dv.validate, "Should not validate")
     assert_equal(dv.error, @expected_error, "Error should be #{@expected_error}")
   end

--- a/test/models/loader/name/distribution/extra_qualifiers_are_rejected_test.rb
+++ b/test/models/loader/name/distribution/extra_qualifiers_are_rejected_test.rb
@@ -12,7 +12,7 @@ class ExtraQualifiersAreRejectedTest < ActiveSupport::TestCase
   end
 
   test "Extra qualifiers are rejected" do
-    dv = Loader::Name::DistributionValidator.new(@dist_s, @allowed_regions) 
+    dv = Loader::Name::DistributionValidator.new(@dist_s, @allowed_regions)
     assert_not(dv.validate, "Should not validate")
     assert_equal(dv.error, @expected_error, "Error should be #{@expected_error}")
   end

--- a/test/models/loader/name/distribution/invalid_region_qualifiers_are_rejected_test.rb
+++ b/test/models/loader/name/distribution/invalid_region_qualifiers_are_rejected_test.rb
@@ -12,7 +12,7 @@ class InvalidRegionQualifiersAreRejectedTest < ActiveSupport::TestCase
   end
 
   test "Invalid region qualifiers are rejected" do
-    dv = Loader::Name::DistributionValidator.new(@dist_s, @allowed_regions) 
+    dv = Loader::Name::DistributionValidator.new(@dist_s, @allowed_regions)
     assert_not(dv.validate, "Should not validate")
     assert_equal(dv.error, @expected_error, "Error should be #{@expected_error}")
   end

--- a/test/models/loader/name/distribution/invalid_regions_are_rejected_test.rb
+++ b/test/models/loader/name/distribution/invalid_regions_are_rejected_test.rb
@@ -12,7 +12,7 @@ class InvalidRegionsAreRejectedTest < ActiveSupport::TestCase
   end
 
   test "Invalid regions are rejected" do
-    dv = Loader::Name::DistributionValidator.new(@dist_s, @allowed_regions) 
+    dv = Loader::Name::DistributionValidator.new(@dist_s, @allowed_regions)
     assert_not(dv.validate, "Should not validate")
     assert_equal(dv.error, @expected_error, "Error should be #{@expected_error}")
   end

--- a/test/models/loader/name/distribution/invalidly_ordered_regions_are_rejected_test.rb
+++ b/test/models/loader/name/distribution/invalidly_ordered_regions_are_rejected_test.rb
@@ -12,7 +12,7 @@ class InvalidlyOrderedRegionsAreRejectedTest < ActiveSupport::TestCase
   end
 
   test "Invalidly ordered regions are rejected" do
-    dv = Loader::Name::DistributionValidator.new(@dist_s, @allowed_regions) 
+    dv = Loader::Name::DistributionValidator.new(@dist_s, @allowed_regions)
     assert_not(dv.validate, "Should not validate")
     assert_equal(dv.error, @expected_error, "Error should be #{@expected_error}")
   end

--- a/test/models/loader/name/distribution/trailing_commas_are_rejected_test.rb
+++ b/test/models/loader/name/distribution/trailing_commas_are_rejected_test.rb
@@ -12,7 +12,7 @@ class DuplicateRegionsAreRejectedTest < ActiveSupport::TestCase
   end
 
   test "Trailing commas are rejected" do
-    dv = Loader::Name::DistributionValidator.new(@dist_s, @allowed_regions) 
+    dv = Loader::Name::DistributionValidator.new(@dist_s, @allowed_regions)
     assert_not(dv.validate, "Should not validate")
     assert_equal(dv.error, @expected_error, "Error should be #{@expected_error}")
   end

--- a/test/models/loader/name/distribution/validator_test.rb
+++ b/test/models/loader/name/distribution/validator_test.rb
@@ -6,7 +6,7 @@ require "test_helper"
 class ValidatorTest < ActiveSupport::TestCase
   test "Can create Validator" do
     allowed_regions = DistRegion.all.order(:sort_order).collect(&:name)
-    dv = Loader::Name::DistributionValidator.new( "Qld (naturalised)", allowed_regions) 
+    dv = Loader::Name::DistributionValidator.new( "Qld (naturalised)", allowed_regions)
     assert(dv.validate)
   end
 end

--- a/test/models/profile/product_item_config_test.rb
+++ b/test/models/profile/product_item_config_test.rb
@@ -56,7 +56,7 @@ module Profile
       assert_includes @product_item_config.errors[:profile_item_type_id], "can't be blank"
     end
 
-    test "order by sort_order asc" do    
+    test "order by sort_order asc" do
       product_item_config = Profile::ProductItemConfig.all
       product_item_config_sort_orders = product_item_config.collect{|p| p.sort_order.to_i}
       assert_equal product_item_config_sort_orders, product_item_config_sort_orders.sort{|x,y| x <=> y}

--- a/test/models/profile/profile_item_test.rb
+++ b/test/models/profile/profile_item_test.rb
@@ -75,7 +75,7 @@ class Profile::ProfileItemTest < ActiveSupport::TestCase
     assert_equal annotation.id, @profile_item.profile_item_annotation.id
   end
 
-  test "order by product item config's sort_order asc" do    
+  test "order by product item config's sort_order asc" do
     profile_items = Profile::ProfileItem.all
     profile_items_sort_orders = profile_items.collect{|p| p.product_item_config.sort_order.to_i}
     assert_equal profile_items_sort_orders, profile_items_sort_orders.sort{|x,y| x <=> y}

--- a/test/models/search/on_reference/citation/hookers_apostrophe_test.rb
+++ b/test/models/search/on_reference/citation/hookers_apostrophe_test.rb
@@ -22,7 +22,7 @@ load "test/models/search/users.rb"
 # Single Search model test for Reference target.
 #
 # In May 2025 I switched from 'english' to 'simple' dictionary and now this
-# test returns zero results - presumably because the 'simple' dictionary does 
+# test returns zero results - presumably because the 'simple' dictionary does
 # not understand apostrophes
 class SearchOnReferenceCitationHookersApostropheTest < ActiveSupport::TestCase
   test "search on reference citation text for hookers apostrophe" do

--- a/test/models/tree/version/no_create_when_read_only_test.rb
+++ b/test/models/tree/version/no_create_when_read_only_test.rb
@@ -12,5 +12,5 @@ class NoCreateWhenReadOnlyTest < ActiveSupport::TestCase
                                           'draft log entry',
                                           false,
                                           'fred')}
-  end 
+  end
 end

--- a/test/models/tree/version/read_only_no_save_test.rb
+++ b/test/models/tree/version/read_only_no_save_test.rb
@@ -6,8 +6,8 @@ require "test_helper"
 class ReadOnlyNoSaveTest < ActiveSupport::TestCase
 
   test "saves" do
-    tree_version_save 
-    tree_draft_version_save 
+    tree_version_save
+    tree_draft_version_save
   end
 
   def tree_version_save
@@ -18,5 +18,5 @@ class ReadOnlyNoSaveTest < ActiveSupport::TestCase
   def tree_draft_version_save
     ron_as_draft = Tree::DraftVersion.find(tree_versions(:ron_draft_version).id)
     assert_raises(Exception) {ron_as_draft.save!}
-  end 
+  end
 end

--- a/test/models/tree/version/writable_save_test.rb
+++ b/test/models/tree/version/writable_save_test.rb
@@ -6,8 +6,8 @@ require "test_helper"
 class WritableSaveTest < ActiveSupport::TestCase
 
   test "saves" do
-    tree_version_save 
-    tree_draft_version_save 
+    tree_version_save
+    tree_draft_version_save
   end
 
   def tree_version_save
@@ -18,5 +18,5 @@ class WritableSaveTest < ActiveSupport::TestCase
   def tree_draft_version_save
     apc_as_draft = Tree::DraftVersion.find(tree_versions(:apc_draft_version).id)
     assert(apc_as_draft.save!, 'Tree::DraftVersion should save')
-  end 
+  end
 end


### PR DESCRIPTION
## Description
Ran` bundle exec rubocop -a --only Layout/TrailingWhitespace`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
BAU Workflows

## Tests
- [x] Unit tests - I ran existing tests
- [ ] Manual testing


## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
