### PR TITLE
Nsl 5860 editor add activity queries for api name and api at

### DIFF
--- a/app/models/audit/defined_query/where_clause/predicate.rb
+++ b/app/models/audit/defined_query/where_clause/predicate.rb
@@ -122,16 +122,22 @@ class Audit::DefinedQuery::WhereClause::Predicate
   }.freeze
 
   WHERE_VALUE_HASH = {
+    "api-name:" => "lower(api_name) like lower(?)",
     "created-by:" => "lower(created_by) like lower(?)",
     "updated-by:" => "lower(updated_by) like lower(?)",
+    "api-recorded-at:" => "api_at::date = ?",
     "created-at:" => "created_at::date = ?",
     "updated-at:" => "updated_at::date = ?",
+    "api-recorded-since:" => "api_at::date >= ?",
     "created-since:" => "created_at::date >= ?",
     "updated-since:" => "updated_at::date >= ?",
+    "api-recorded-after:" => "api_at::date >= ?",
     "created-after:" => "created_at::date >= ?",
     "updated-after:" => "updated_at::date >= ?",
+    "api-recorded-before:" => "api_at::date < ?",
     "created-before:" => "created_at::date < ?",
     "updated-before:" => "updated_at::date < ?",
+    "date-api-recorded:" => "date_trunc('day',api_at) = ?",
     "date-created:" => "date_trunc('day',created_at) = ?",
     "date-last-updated:" => "date_trunc('day',updated_at) = ?",
   }.freeze

--- a/app/views/audits/advanced_search/editor/_examples.html.erb
+++ b/app/views/audits/advanced_search/editor/_examples.html.erb
@@ -17,6 +17,20 @@
       {search_target: "Activity",
        search_string: "date-created-or-last-updated: 2015-09-07",
        explanation: %Q(Records created or last updated on 7 Sept 2015.)},
+      {search_target: "Activity",
+       search_string: "api-name: jira-sync",
+       explanation: %Q(Records last changed by the "jira-sync" API.
+                       Case-insensitive; use * as a wildcard.)},
+      {search_target: "Activity",
+       search_string: "api-recorded-at: 2026-06-30",
+       explanation: %Q(Records changed by an API on 30 June 2026.)},
+      {search_target: "Activity",
+       search_string: "api-name: jira-sync* api-recorded-after: 2026-06-30",
+       explanation: %Q(Records changed by an API whose name starts with
+                       "jira-sync" on or after 30 June 2026.)},
+      {search_target: "Activity",
+       search_string: "api-recorded-before: 2026-06-30 names-only:",
+       explanation: %Q(Names changed by an API before 30 June 2026.)},
       ].each do |val| %>
   <tr>
     <td class="width-30-percent">
@@ -49,6 +63,12 @@
       {search_target: "Activity",
        search_string: "count date-created-or-last-updated: 2015-09-07",
        explanation: %Q(Count records created or last updated on 7 Sept 2015.)},
+      {search_target: "Activity",
+       search_string: "count api-name: jira-sync",
+       explanation: %Q(Count records last changed by the "jira-sync" API.)},
+      {search_target: "Activity",
+       search_string: "count api-recorded-since: 2026-06-30",
+       explanation: %Q(Count records changed by an API on or after 30 June 2026.)},
       ].each do |val| %>
   <tr>
     <td class="width-30-percent">

--- a/app/views/audits/advanced_search/editor/_field_help.html.erb
+++ b/app/views/audits/advanced_search/editor/_field_help.html.erb
@@ -48,6 +48,34 @@
   <% end %>
 </table>
 
+<h5>Restrict API activity</h5>
+<table class="table table-striped">
+  <tr><th>Field</th><th>Description</th></tr>
+  <% [
+    {field_name: 'api-name:', description: "search for records last changed by an API with that name, case-insensitive; use * as a wildcard e.g. jira-sync*"},
+    {field_name: 'api-recorded-at: yyyy-mm-dd', description: "search for records changed by an API on a specific day e.g. 2026-06-30"},
+    {field_name: 'api-recorded-since: yyyy-mm-dd', description: "search for records changed by an API on or after a specific day e.g. 2026-06-30"},
+    {field_name: 'api-recorded-after: yyyy-mm-dd', description: "search for records changed by an API on or after a specific day e.g. 2026-06-30"},
+    {field_name: 'api-recorded-before: yyyy-mm-dd', description: "search for records changed by an API before a specific day e.g. 2026-06-30"},
+    {field_name: 'date-api-recorded: yyyy-mm-dd', description: "search for records changed by an API on a specific day e.g. 2026-06-30"},
+      ].each do |val| %>
+  <tr>
+    <td class="width-20-percent">
+      <a href="javascript:void(0)" class="searchable-field width-100-percent"
+         data-search-directive="<%= val[:field_name] %>"
+         title='Add "<%= val[:field_name] %>" field to search.'>
+        <span class="blue"><%= val[:field_name] %></span>
+      </a>
+    </td>
+    <td><%= val[:description].html_safe %>
+    <% if val[:partial].present? %>
+      <%= render partial: val[:partial] %>
+    <% end %>
+    </td>
+  </tr>
+  <% end %>
+</table>
+
 
 <h5>Assertions to restrict record types</h5>
 <table class="table table-striped">

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 31-July-2026
+  :jira_id: '5860'
+  :description: |-
+    Query directives for api_name and api_at in activity search
+- :date: 31-July-2026
   :jira_id: '4883'
   :description: |-
     Orchids code: Remove some remnant Orchid loader code - BAU workflow testing only

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.75
+appversion=5.1.4.76

--- a/test/models/search/audit/api_at/simple_test.rb
+++ b/test/models/search/audit/api_at/simple_test.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Search model tests for the api-recorded-at: / api-recorded-since: /
+# api-recorded-after: / api-recorded-before: / date-api-recorded:
+# activity (audit) search directives.
+class SearchAuditApiAtSimpleTest < ActiveSupport::TestCase
+  setup do
+    names(:a_family).update_columns(api_name: "JIRA-Sync",
+      api_at: Time.utc(2026, 7, 27, 12))
+    references(:paper_by_brassard)
+      .update_columns(api_name: "JIRA-Sync",
+        api_at: Time.utc(2026, 8, 15, 12))
+    authors(:brassard).update_columns(api_name: nil, api_at: nil)
+  end
+
+  def build_qa_user
+    qa_user = SessionUser.new
+    qa_user.username = "qa-tester"
+    qa_user.full_name = "a QA tester"
+    qa_user.groups = ["QA"]
+    qa_user
+  end
+
+  def search_keys(query_string)
+    params = ActiveSupport::HashWithIndifferentAccess.new(
+      query_target: "activity",
+      query_string: query_string,
+      current_user: build_qa_user
+    )
+    search = Search::Base.new(params)
+    search.executed_query.results.collect { |r| "#{r.class.base_class.name}##{r.id}" }
+  end
+
+  test "api-recorded-at: matches a record changed on that date" do
+    assert_includes search_keys("api-recorded-at: 2026-07-27"),
+      "Name##{names(:a_family).id}",
+      "Expected the name api-changed on 27-07-2026 in the results"
+  end
+
+  test "api-recorded-at: excludes a record changed on another date" do
+    refute_includes search_keys("api-recorded-at: 2026-07-27"),
+      "Reference##{references(:paper_by_brassard).id}",
+      "Expected the reference api-changed on 15-08-2026 to be excluded"
+  end
+
+  test "api-recorded-at: excludes records never changed by an api" do
+    refute_includes search_keys("api-recorded-at: 2026-07-27"),
+      "Author##{authors(:brassard).id}",
+      "Expected an author with no api_at to be excluded"
+  end
+
+  test "api-recorded-since: matches records changed on or after the date" do
+    keys = search_keys("api-recorded-since: 2026-07-27")
+    assert_includes keys,
+      "Name##{names(:a_family).id}",
+      "Expected a record api-changed on the boundary date to match"
+    assert_includes keys,
+      "Reference##{references(:paper_by_brassard).id}",
+      "Expected a record api-changed after the date to match"
+  end
+
+  test "api-recorded-since: excludes records changed before the date" do
+    refute_includes search_keys("api-recorded-since: 2026-08-01"),
+      "Name##{names(:a_family).id}",
+      "Expected a record api-changed in July to be excluded"
+  end
+
+  test "api-recorded-after: matches records changed on or after the date" do
+    keys = search_keys("api-recorded-after: 2026-08-01")
+    assert_includes keys,
+      "Reference##{references(:paper_by_brassard).id}",
+      "Expected a record api-changed after the date to match"
+    refute_includes keys,
+      "Name##{names(:a_family).id}",
+      "Expected a record api-changed before the date to be excluded"
+  end
+
+  test "api-recorded-before: matches records changed before the date only" do
+    keys = search_keys("api-recorded-before: 2026-08-01")
+    assert_includes keys,
+      "Name##{names(:a_family).id}",
+      "Expected a record api-changed in July to match"
+    refute_includes keys,
+      "Reference##{references(:paper_by_brassard).id}",
+      "Expected a record api-changed in August to be excluded"
+  end
+
+  test "api-recorded-before: excludes records changed on the date itself" do
+    refute_includes search_keys("api-recorded-before: 2026-07-27"),
+      "Name##{names(:a_family).id}",
+      "Expected the boundary date itself to be excluded"
+  end
+
+  test "date-api-recorded: matches records changed on that day" do
+    keys = search_keys("date-api-recorded: 2026-07-27")
+    assert_includes keys,
+      "Name##{names(:a_family).id}",
+      "Expected the name api-changed on 27-07-2026 in the results"
+    refute_includes keys,
+      "Reference##{references(:paper_by_brassard).id}",
+      "Expected the reference api-changed on 15-08-2026 to be excluded"
+  end
+
+  test "api-recorded-at: without a value stops with an error" do
+    error = assert_raises(RuntimeError) { search_keys("api-recorded-at:") }
+    assert_match(/api-recorded-at: needs a value/, error.message)
+  end
+end

--- a/test/models/search/audit/api_name/simple_test.rb
+++ b/test/models/search/audit/api_name/simple_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Search model tests for the api-name: activity (audit) search directive.
+class SearchAuditApiNameSimpleTest < ActiveSupport::TestCase
+  setup do
+    names(:a_family).update_columns(api_name: "JIRA-Sync",
+      api_at: Time.utc(2026, 7, 27, 12))
+    references(:paper_by_brassard)
+      .update_columns(api_name: "batch-loader",
+        api_at: Time.utc(2026, 8, 15, 12))
+    authors(:brassard).update_columns(api_name: nil, api_at: nil)
+  end
+
+  def build_qa_user
+    qa_user = SessionUser.new
+    qa_user.username = "qa-tester"
+    qa_user.full_name = "a QA tester"
+    qa_user.groups = ["QA"]
+    qa_user
+  end
+
+  def search_keys(query_string)
+    params = ActiveSupport::HashWithIndifferentAccess.new(
+      query_target: "activity",
+      query_string: query_string,
+      current_user: build_qa_user
+    )
+    search = Search::Base.new(params)
+    search.executed_query.results.collect { |r| "#{r.class.base_class.name}##{r.id}" }
+  end
+
+  test "api-name: matches a name record changed by that api" do
+    assert_includes search_keys("api-name: jira-sync"),
+      "Name##{names(:a_family).id}",
+      "Expected the name changed by JIRA-Sync in the results"
+  end
+
+  test "api-name: is case-insensitive" do
+    assert_includes search_keys("api-name: JIRA-SYNC"),
+      "Name##{names(:a_family).id}",
+      "Expected a different-case search to match"
+  end
+
+  test "api-name: excludes records changed by another api" do
+    refute_includes search_keys("api-name: jira-sync"),
+      "Reference##{references(:paper_by_brassard).id}",
+      "Expected the reference changed by batch-loader to be excluded"
+  end
+
+  test "api-name: supports wildcards" do
+    keys = search_keys("api-name: *loader*")
+    assert_includes keys,
+      "Reference##{references(:paper_by_brassard).id}",
+      "Expected a wildcard search to match batch-loader"
+    refute_includes keys,
+      "Name##{names(:a_family).id}",
+      "Expected a *loader* search to exclude JIRA-Sync"
+  end
+
+  test "api-name: matches records across record types" do
+    keys = search_keys("api-name: *")
+    assert_includes keys,
+      "Name##{names(:a_family).id}",
+      "Expected the api-changed name in the results"
+    assert_includes keys,
+      "Reference##{references(:paper_by_brassard).id}",
+      "Expected the api-changed reference in the results"
+  end
+
+  test "api-name: excludes records never changed by an api" do
+    refute_includes search_keys("api-name: *"),
+      "Author##{authors(:brassard).id}",
+      "Expected an author with no api_name to be excluded"
+  end
+
+  test "api-name: without a value stops with an error" do
+    error = assert_raises(RuntimeError) { search_keys("api-name:") }
+    assert_match(/api-name: needs a value/, error.message)
+  end
+end

--- a/test/models/search/audit/api_name/simple_test.rb
+++ b/test/models/search/audit/api_name/simple_test.rb
@@ -91,6 +91,16 @@ class SearchAuditApiNameSimpleTest < ActiveSupport::TestCase
       "Expected an author with no api_name to be excluded"
   end
 
+  test "api-name: combines with api-recorded-after:" do
+    keys = search_keys("api-name: *loader* api-recorded-after: 2026-08-01")
+    assert_includes keys,
+      "Reference##{references(:paper_by_brassard).id}",
+      "Expected the batch-loader reference api-changed in August to match"
+    refute_includes keys,
+      "Name##{names(:a_family).id}",
+      "Expected the JIRA-Sync name to be excluded by both criteria"
+  end
+
   test "api-name: without a value stops with an error" do
     error = assert_raises(RuntimeError) { search_keys("api-name:") }
     assert_match(/api-name: needs a value/, error.message)


### PR DESCRIPTION
## Description
Implement query directive for api name/at in activity search

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
