### PR TITLE
NSL-5568: Intermittent 406 errors: Add code switches we expect will prevent these problems happening

### DIFF
--- a/app/views/search/_top_navbar.html.erb
+++ b/app/views/search/_top_navbar.html.erb
@@ -84,6 +84,7 @@
                         de_duplicates_index_path,
                         class: "main-body-tab-link xhidden",
                         remote: true,
+                        data: { turbo: false },
                         title: "De-duplicate names in bulk" %>
           </li>
         <% end %>
@@ -97,6 +98,7 @@
                       id: "batch-loader-console-tab-link",
                       class: "main-body-tab-link",
                       remote: true,
+                      data: { turbo: false },
                       title: "Batch Loader work area" %>
         </li>
       <% end %>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 03-August-2026
+  :jira_id: '5568'
+  :description: |-
+    Intermittent 406 errors: Add code switches we expect will prevent these problems happening
+- :date: 03-August-2026
   :jira_id: '5858'
   :description: |-
     Make asterisks indicating mandatory fields consistent in the forms

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.79
+appversion=5.1.4.80


### PR DESCRIPTION
## Description
From Claude:

Confirmed, and it changes the root cause — this isn't about the click at all, it's a known conflict in this codebase between Turbo Drive and Rails-UJS.

app/javascript/application.js imports @hotwired/turbo-rails with Turbo.session.drive left enabled (that line is commented out). Turbo Drive intercepts same-origin link clicks globally by default — it doesn't automatically defer to data-remote="true" links the way old Turbolinks Classic did. So the "Batch" link's remote: true (meant for Rails-UJS to handle as an AJAX request expecting Accept: text/javascript) is also a valid target for Turbo Drive, which instead issues a fetch with Accept: text/html. Whichever library's document-level click listener processes the event first wins; when Turbo wins, you get a request with Accept: text/html hitting an action that only has index.js.erb — the same 406.

This is a known, already-solved problem in this exact codebase: I found ~40 other remote: true forms and links throughout the app that explicitly add data: { turbo: false } to opt out of Turbo Drive (e.g. every form under app/views/loader/names/tabs/forms/, app/views/loader/batches/tabs/_form.html.erb, etc.). That's the established pattern here specifically to prevent this conflict. The "Batch" link in _top_navbar.html.erb is missing it — and so is the "De-duplicate" link right above it (lines 83–88), which has the identical remote: true pattern with no turbo: false guard.

That also explains "opened in a new tab": a brand-new tab is a fresh full HTTP page load, which is exactly when Turbo has to (re-)initialize its session from scratch — a more timing-sensitive moment for this kind of listener race than clicking around within an already-running Turbo session.

Fix: add data: { turbo: false } to the loader_batches_path link (and the De-duplicate link, same bug):

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
Intermittent error - see Jira.  Click the Batch and De-duplicate tabs will test normal behaviour.

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
