### PR TITLE
NSL-5568: Intermittent 406 errors: Many more links needed the turbo-f…alse switch to avoid potential 406 errors

### DIFF
--- a/app/views/application/search_results/_loader_name_record.html.erb
+++ b/app/views/application/search_results/_loader_name_record.html.erb
@@ -33,7 +33,7 @@
       <%= link_to('<i class="fa-solid fa-plus"></i>'.html_safe, loader_name_new_row_here_path(search_result.id),
                   title: 'Start a new loader-name record',
                   class: 'inline display-only-when-showing-details',
-                  remote: true) %>
+                  remote: true, data: { turbo: false }) %>
     <% end %>
 
     <% unless search_result.remark_to_reviewers.blank? %>

--- a/app/views/authors/_delete_widgets.html.erb
+++ b/app/views/authors/_delete_widgets.html.erb
@@ -13,7 +13,7 @@
                                  class: "btn btn-danger confirm-delete-btn",
                                  tabindex: increment_tab_index,
                                  title: "Confirm you want to delete the author.",
-                                 remote: true,
+                                 remote: true, data: { turbo: false },
                                  method: :delete)
 %>
 

--- a/app/views/authors/_form.html.erb
+++ b/app/views/authors/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(@author, as: 'author', role: 'form', remote: true
+<%= form_for(@author, as: 'author', role: 'form', remote: true, data: { turbo: false }
     ) do |f| %>
     <% if @author.errors.any? %>
         <div id="error_explanation">

--- a/app/views/comments/_delete_widgets.html.erb
+++ b/app/views/comments/_delete_widgets.html.erb
@@ -13,7 +13,7 @@
                                  class: "btn btn-danger confirm-delete-btn",
                                  tabindex: increment_tab_index,
                                  title: "Confirm you want to delete the comment.",
-                                 remote: true,
+                                 remote: true, data: { turbo: false },
                                  method: :delete)
 %>
 

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,7 +1,7 @@
 
 <% comment ||= @comment if @comment.present? %>
 
-<%= form_for(comment, remote: true, class: 'comment-edit-form') do |f| %>
+<%= form_for(comment, remote: true, data: { turbo: false }, class: 'comment-edit-form') do |f| %>
   <% if comment.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(comment.errors.count, "error") %> prohibited this comment from being saved:</h2>

--- a/app/views/comments/_form_new.html.erb
+++ b/app/views/comments/_form_new.html.erb
@@ -1,7 +1,7 @@
 <% @comment ||= comment %>
 
 
-<%= form_for(@comment, remote: true, class: 'instance-note-edit-form') do |f| %>
+<%= form_for(@comment, remote: true, data: { turbo: false }, class: 'instance-note-edit-form') do |f| %>
   <% if @comment.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@comment.errors.count, "error") %> prohibited this comment from being saved:</h2>

--- a/app/views/instance_notes/_form.html.erb
+++ b/app/views/instance_notes/_form.html.erb
@@ -1,6 +1,6 @@
 <% @instance_note = instance_note %>
 
-<%= form_for(@instance_note, remote: true, class: 'instance-note-edit-form') do |f| %>
+<%= form_for(@instance_note, remote: true, data: { turbo: false }, class: 'instance-note-edit-form') do |f| %>
   <% if @instance_note.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@instance_note.errors.count, "error") %> prohibited this instance_note from being saved:</h2>
@@ -80,7 +80,7 @@
                                  class: "btn btn-danger", 
                                  tabindex: increment_tab_index,
                                  title: "Select to confirm the delete.",
-                                 remote: true, 
+                                 remote: true, data: { turbo: false }, 
                                  method: :delete) 
 %>
  

--- a/app/views/instance_notes/_form_new.html.erb
+++ b/app/views/instance_notes/_form_new.html.erb
@@ -1,7 +1,7 @@
 <% @instance_note = instance_note %>
 
 
-<%= form_for(@instance_note, remote: true, class: 'instance-note-edit-form') do |f| %>
+<%= form_for(@instance_note, remote: true, data: { turbo: false }, class: 'instance-note-edit-form') do |f| %>
   <% if @instance_note.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@instance_note.errors.count, "error") %> prohibited this instance_note from being saved:</h2>

--- a/app/views/instance_notes/show.html.erb
+++ b/app/views/instance_notes/show.html.erb
@@ -4,18 +4,19 @@
                        edit_instance_note_path(instance_note.id), 
                        id: "instance-note-edit-link-#{instance_note.id}", 
                        class: "btn btn-default instance-note-edit-link", 
-                       remote: true, 
-                       data: {type: 'script'}) 
+                       remote: true,
+                       data: {type: 'script', turbo: false})
 %>
  
 <% cancel_edit_link = link_to("Cancel",
                        '',
                        id: "instance-note-cancel-edit-link-#{instance_note.id}",
                        class: "btn btn-default instance-note-cancel-edit-link hidden", 
-                       remote: true, 
+                       remote: true,
                        title: 'Cancel edit',
                        data: {type: 'script',
-                              instance_note_id: instance_note.id})
+                              instance_note_id: instance_note.id,
+                              turbo: false})
 %>
 
 <%= render partial: 'detail_line', 

--- a/app/views/instances/_add_instance_note.html.erb
+++ b/app/views/instances/_add_instance_note.html.erb
@@ -1,6 +1,6 @@
 <%= form_for(InstanceNote.new, 
              url: instance_notes_path,
-             remote: true,
+             remote: true, data: { turbo: false },
              html:{class:"form-inline",
                    data: {type: 'script'}
                   }) do |f| %>

--- a/app/views/instances/_delete_widgets.html.erb
+++ b/app/views/instances/_delete_widgets.html.erb
@@ -29,7 +29,7 @@
                                    class: "btn btn-danger confirm-delete-btn",
                                    tabindex: increment_tab_index,
                                    title: "Confirm the delete.",
-                                   remote: true,
+                                   remote: true, data: { turbo: false },
                                    method: :delete)
   -%>
 

--- a/app/views/instances/_form_change_name.html.erb
+++ b/app/views/instances/_form_change_name.html.erb
@@ -2,7 +2,7 @@
 <div>Change the name for this draft instance.</div>
 <%= form_for(@instance,
              url: instance_name_path(@instance),
-             html: { id: "change-name-form", method: :patch, remote: true }) do |f| %>
+             html: { id: "change-name-form", method: :patch, remote: true, data: { turbo: false } }) do |f| %>
   <input id="instance-name-change-typeahead"
          name="instance[name_typeahead]"
          class="typeahead form-control"

--- a/app/views/instances/_form_create_from_name.html.erb
+++ b/app/views/instances/_form_create_from_name.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(@instance, remote: true) do |f| %>
+<%= form_for(@instance, remote: true, data: { turbo: false }) do |f| %>
 
     <%= show_field_as_linked_lookup('',@instance.name,'full_name', search_path(query_string: %Q(id:#{@instance.name_id}),query_target: 'name'),'name') %>
     appears in reference*

--- a/app/views/instances/_form_create_from_reference.html.erb
+++ b/app/views/instances/_form_create_from_reference.html.erb
@@ -1,5 +1,5 @@
 
-<%= form_for(Instance.new,  url: { controller: 'instances', action: "create" }, remote: true) do |f| %>
+<%= form_for(Instance.new,  url: { controller: 'instances', action: "create" }, remote: true, data: { turbo: false }) do |f| %>
     <% if @instance && @instance.errors.any? %>
         <div id="error_explanation">
             <h2><%= pluralize(@instance.errors.count, "error") %> prohibited this instance from being saved:</h2>

--- a/app/views/instances/_form_create_synonymy.html.erb
+++ b/app/views/instances/_form_create_synonymy.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(Instance.new, url: { action: "create_cites_and_cited_by" }, remote: true) do |f| %>
+<%= form_for(Instance.new, url: { action: "create_cites_and_cited_by" }, remote: true, data: { turbo: false }) do |f| %>
 <% if @instance.errors.any? %>
 <div id="error_explanation">
   <h2><%= pluralize(@instance.errors.count, "error") %> prohibited this instance from being saved:</h2>

--- a/app/views/instances/_form_create_unpublished_citation.html.erb
+++ b/app/views/instances/_form_create_unpublished_citation.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(Instance.new,  url: { action: "create_cited_by" }, remote: true) do |f| %>
+<%= form_for(Instance.new,  url: { action: "create_cited_by" }, remote: true, data: { turbo: false }) do |f| %>
     <% if @instance.errors.any? %>
         <div id="error_explanation">
             <h2><%= pluralize(@instance.errors.count, "error") %> prohibited this instance from being saved:</h2>

--- a/app/views/instances/_form_update_standalone.html.erb
+++ b/app/views/instances/_form_update_standalone.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(@instance, remote: true) do |f| %>
+<%= form_for(@instance, remote: true, data: { turbo: false }) do |f| %>
     <% if @instance.errors.any? %>
         <div id="error_explanation">
             <h2><%= pluralize(@instance.errors.count, "error") %> prohibited this instance from being saved:</h2>

--- a/app/views/instances/_form_update_synonymy.html.erb
+++ b/app/views/instances/_form_update_synonymy.html.erb
@@ -3,7 +3,7 @@
     concept.
   </div>
 <% end %>
-<%= form_for(@instance, remote: true) do |f| %>
+<%= form_for(@instance, remote: true, data: { turbo: false }) do |f| %>
   <% if @instance.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@instance.errors.count, "error") %> prohibited this instance from being saved:</h2>

--- a/app/views/instances/_form_update_unpublished_citation.html.erb
+++ b/app/views/instances/_form_update_unpublished_citation.html.erb
@@ -3,7 +3,7 @@
     accepted concept.
   </div>
 <% end %>
-<%= form_for(@instance, remote: true) do |f| %>
+<%= form_for(@instance, remote: true, data: { turbo: false }) do |f| %>
     <% if @instance.errors.any? %>
         <div id="error_explanation">
             <h2><%= pluralize(@instance.errors.count, "error") %> prohibited this instance from being saved:</h2>

--- a/app/views/instances/_soft_delete_widgets.html.erb
+++ b/app/views/instances/_soft_delete_widgets.html.erb
@@ -22,7 +22,7 @@
                                   class: "btn btn-danger confirm-soft-delete-btn",
                                   tabindex: increment_tab_index,
                                   title: "Confirm the soft delete.",
-                                  remote: true,
+                                  remote: true, data: { turbo: false },
                                   method: :post)
 -%>
 

--- a/app/views/instances/_update_reference_id_widgets.html.erb
+++ b/app/views/instances/_update_reference_id_widgets.html.erb
@@ -8,7 +8,7 @@ Change the reference for this instance and its
 
 <br>
 <br>
-<%= form_for(@instance, url: {action: 'change_reference'}, html: {id: "change-reference-form", class: "change-reference-form", method: :patch, remote: true}) do |f| %>
+<%= form_for(@instance, url: {action: 'change_reference'}, html: {id: "change-reference-form", class: "change-reference-form", method: :patch, remote: true, data: { turbo: false }}) do |f| %>
     <% if @instance.errors.any? %>
         <div id="error_explanation">
           <h2><%= pluralize(@instance.errors.count, "error") %> prohibited this instance from being saved:</h2>

--- a/app/views/instances/tabs/_tab_copy_to_new_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_copy_to_new_profile_v2.html.erb
@@ -28,7 +28,7 @@
               url: { action: "copy_for_profile_v2",
               format: 'js'},
               id: "copy-instance-for-name-form",
-              remote: true,
+              remote: true, data: { turbo: false },
               method: :post) do |f| %>
 
     <br>

--- a/app/views/instances/tabs/_tab_copy_to_new_reference.html.erb
+++ b/app/views/instances/tabs/_tab_copy_to_new_reference.html.erb
@@ -22,7 +22,7 @@ The copied instance will remain attached to:
              url: { action: "copy_standalone",
              format: 'js'}, 
              id: "copy-instance-for-name-form",
-             remote: true, 
+             remote: true, data: { turbo: false }, 
              method: :post) do |f| %>
 
   <br>

--- a/app/views/instances/tabs/_tab_synonymy_for_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_synonymy_for_profile_v2.html.erb
@@ -1,6 +1,6 @@
 <h5>Create a synonym</h5>
 
-<%= form_for(Instance.new, url: { action: "create_cites_and_cited_by" }, remote: true) do |f| %>
+<%= form_for(Instance.new, url: { action: "create_cites_and_cited_by" }, remote: true, data: { turbo: false }) do |f| %>
   <% if @instance.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@instance.errors.count, "error") %> prohibited this instance from being saved:</h2>

--- a/app/views/instances/tabs/_tab_unpublished_citation_for_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_unpublished_citation_for_profile_v2.html.erb
@@ -1,6 +1,6 @@
 <h5>Create an unpublished citation.</h5>
 
-<%= form_for(Instance.new,  url: { action: "create_cited_by" }, remote: true) do |f| %>
+<%= form_for(Instance.new,  url: { action: "create_cited_by" }, remote: true, data: { turbo: false }) do |f| %>
     <% if @instance.errors.any? %>
         <div id="error_explanation">
             <h2><%= pluralize(@instance.errors.count, "error") %> prohibited this instance from being saved:</h2>

--- a/app/views/instances/workspace/_draft_placement.html.erb
+++ b/app/views/instances/workspace/_draft_placement.html.erb
@@ -32,7 +32,7 @@
       <dt><%= @tree_version_element.comment_key %></dt>
       <dd>
         <div>
-          <%= form_tag({controller: 'trees', action: 'update_comment'}, {method: :post, remote: true}) do %>
+          <%= form_tag({controller: 'trees', action: 'update_comment'}, {method: :post, remote: true, data: { turbo: false }}) do %>
             <%= hidden_field_tag("update_comment[element_link]", @tree_version_element.element_link) %>
             <% if @tree_version_element.comment.blank? %>
               <%= render partial: "trees/add_comment", locals: {tree_version_element: @tree_version_element} %>
@@ -46,7 +46,7 @@
   
       <dt><%= @tree_version_element.distribution_key %></dt>
       <dd><%= @tree_version_element.distribution %>
-        <%= form_tag({controller: 'trees', action: 'update_distribution'}, {method: :post, remote: true}) do %>
+        <%= form_tag({controller: 'trees', action: 'update_distribution'}, {method: :post, remote: true, data: { turbo: false }}) do %>
           <%= hidden_field_tag("update_distribution[element_link]", @tree_version_element.element_link) %>
           <% if @tree_version_element.distribution.blank? %>
             <%= render partial: "trees/add_distribution", locals: {tree_version_element: @tree_version_element} %>
@@ -63,7 +63,7 @@
 
     <dt></dt>
     <dd>
-      <%= form_tag({controller: 'trees', action: 'update_tree_parent'}, {method: :post, remote: true}) do %>
+      <%= form_tag({controller: 'trees', action: 'update_tree_parent'}, {method: :post, remote: true, data: { turbo: false }}) do %>
         <%= hidden_field_tag("update_parent[element_link]", @tree_version_element.element_link) %>
         <%= render partial: "trees/update_parent", locals: {parent_tve: @tree_version_element.parent} %>
         <button type="submit"

--- a/app/views/instances/workspace/_new_placement.html.erb
+++ b/app/views/instances/workspace/_new_placement.html.erb
@@ -7,7 +7,7 @@
         </span>
       </span>
     </h1>
-    <%= form_tag({controller: 'trees', action: 'place_name'}, {method: :post, remote: true}) do %>
+    <%= form_tag({controller: 'trees', action: 'place_name'}, {method: :post, remote: true, data: { turbo: false }}) do %>
       <%= hidden_field_tag("place_name[instance_id]", @instance.id) %>
 
       <div>

--- a/app/views/instances/workspace/_remove_placement.html.erb
+++ b/app/views/instances/workspace/_remove_placement.html.erb
@@ -2,7 +2,7 @@
   <% if @tree_version_element.present? %>
 
     <div>
-      <%= form_tag({controller: 'trees', action: 'remove_name_placement'}, {method: :delete, remote: true}) do %>
+      <%= form_tag({controller: 'trees', action: 'remove_name_placement'}, {method: :delete, remote: true, data: { turbo: false }}) do %>
         <%= hidden_field_tag("remove_placement[taxon_uri]", @tree_version_element.element_link) %>
 
         <h3>Remove <%= @instance.name.full_name_html.html_safe %> from

--- a/app/views/instances/workspace/_replace_placement.html.erb
+++ b/app/views/instances/workspace/_replace_placement.html.erb
@@ -10,7 +10,7 @@
     <h1>Replace instance:
       <%= render partial: "instances/workspace/widgets/placement_indicator", locals: {tree_version_element: @tree_version_element} %>
     </h1>
-    <%= form_tag({controller: 'trees', action: 'replace_placement'}, {method: :patch, remote: true}) do %>
+    <%= form_tag({controller: 'trees', action: 'replace_placement'}, {method: :patch, remote: true, data: { turbo: false }}) do %>
       <%= hidden_field_tag("move_placement[element_link]", @tree_version_element.element_link) %>
       <%= hidden_field_tag("move_placement[instance_id]", @instance.id) %>
 

--- a/app/views/instances/workspace/widgets/_delete_button.html.erb
+++ b/app/views/instances/workspace/widgets/_delete_button.html.erb
@@ -6,5 +6,5 @@
                        name: "delete_placement[delete]",
                        tabindex: increment_tab_index,
                        method: :delete,
-                       remote: true,
+                       remote: true, data: { turbo: false },
                        title: "Select to delete this value."} %>

--- a/app/views/layouts/_batch_menu.html.erb
+++ b/app/views/layouts/_batch_menu.html.erb
@@ -15,14 +15,14 @@
                 {class: 'blue',
                  title: "Clear the default batch",
                  method: :post,
-                 remote: true}) %>
+                 remote: true, data: { turbo: false }}) %>
           <% else %>
             <%= link_to("#{batch.name}".html_safe,
                 make_default_batch_path(batch.id, 'from-menu'),
                 {class: 'blue',
                  title: "Make #{batch.name} the default batch",
                  method: :post,
-                 remote: true}) %>
+                 remote: true, data: { turbo: false }}) %>
           <% end %>
         </li>
       <% end %>

--- a/app/views/layouts/_help_menu.html.erb
+++ b/app/views/layouts/_help_menu.html.erb
@@ -8,25 +8,25 @@
     </a>
     <ul id="create-dropdown-menu" class="dropdown-menu" role="menu">
       <li role="presentation">
-        <%= link_to "Overview", help_index_path, title: 'View editor help', tabindex: '-1', remote: true %>
+        <%= link_to "Overview", help_index_path, title: 'View editor help', tabindex: '-1', remote: true, data: { turbo: false } %>
       </li>
       <li role="presentation">
-        <%= link_to "How to search", help_how_to_search_path, title: 'View how to search help', tabindex: '-1', remote: true %>
+        <%= link_to "How to search", help_how_to_search_path, title: 'View how to search help', tabindex: '-1', remote: true, data: { turbo: false } %>
       </li>
       <li role="presentation">
-        <%= link_to "Name rules", help_name_rules_path, title: 'See the name rules', tabindex: '-1', remote: true %>
+        <%= link_to "Name rules", help_name_rules_path, title: 'See the name rules', tabindex: '-1', remote: true, data: { turbo: false } %>
       </li>
       <li role="presentation">
-        <%= link_to "Reference type rules", ref_type_rules_path, title: 'See reference type rules', tabindex: '-1', remote: true %>
+        <%= link_to "Reference type rules", ref_type_rules_path, title: 'See reference type rules', tabindex: '-1', remote: true, data: { turbo: false } %>
       </li>
       <li role="presentation">
-        <%= link_to "Instance models", instance_models_path, title: 'See diagrams modelling instances', tabindex: '-1', remote: true %>
+        <%= link_to "Instance models", instance_models_path, title: 'See diagrams modelling instances', tabindex: '-1', remote: true, data: { turbo: false } %>
       </li>
       <li role="presentation">
-        <%= link_to "Typeaheads", typeaheads_path, title: 'About typeahead fields', tabindex: '-1', remote: true %>
+        <%= link_to "Typeaheads", typeaheads_path, title: 'About typeahead fields', tabindex: '-1', remote: true, data: { turbo: false } %>
       </li>
       <li role="presentation">
-        <%= link_to "Instance Types", instance_types_path, title: 'List of instance types', tabindex: '-1', remote: true %>
+        <%= link_to "Instance Types", instance_types_path, title: 'List of instance types', tabindex: '-1', remote: true, data: { turbo: false } %>
       </li>
       <li role="presentation" class="divider"></li>
       <li role="presentation">

--- a/app/views/layouts/_new_menu.html.erb
+++ b/app/views/layouts/_new_menu.html.erb
@@ -15,7 +15,7 @@
         <%= link_to "Author",
                     author_new_row_path,
                     title: 'Add new Author',
-                    remote: true,
+                    remote: true, data: { turbo: false },
                     tabindex: '-1' %>
       </li>
 
@@ -24,7 +24,7 @@
           <%= link_to "Reference",
                     reference_new_row_path,
                     title: 'Add a new reference',
-                    remote: true,
+                    remote: true, data: { turbo: false },
                     tabindex: '-1' %>
         </li>
 
@@ -45,7 +45,7 @@
               <%= link_to "Accepted or excluded record",
                         loader_name_new_row_path,
                         {title: "Add a new accepted or excluded loader-name to batch #{session[:default_loader_batch_name]}",
-                         remote: true,
+                         remote: true, data: { turbo: false },
                          tabindex: '-1'} %>
             </li>
 
@@ -53,7 +53,7 @@
               <%= link_to "Heading",
                         loader_name_new_heading_row_path,
                         title: "Add a new heading loader-name record within batch #{session[:default_loader_batch_name]}",
-                        remote: true,
+                        remote: true, data: { turbo: false },
                         tabindex: '-1' %>
             </li>
 
@@ -61,7 +61,7 @@
               <%= link_to "Batch note",
                         loader_name_new_in_batch_note_row_path,
                         title: 'Add a new "in-batch-note" loader-name within the current loader-batch',
-                        remote: true,
+                        remote: true, data: { turbo: false },
                         tabindex: '-1' %>
             </li>
 
@@ -73,7 +73,7 @@
               <%= link_to "Loader Batch",
                         loader_batch_new_row_path,
                         {title: "Add a new loader batch",
-                         remote: true,
+                         remote: true, data: { turbo: false },
                          tabindex: '-1'} %>
             </li>
 
@@ -83,7 +83,7 @@
             <%= link_to "User",
                         user_new_row_path,
                         title: 'Add User',
-                        remote: true,
+                        remote: true, data: { turbo: false },
                         tabindex: '-1' %>
           </li>
         <% end %>

--- a/app/views/layouts/_new_multi_product_menu.html.erb
+++ b/app/views/layouts/_new_multi_product_menu.html.erb
@@ -22,7 +22,7 @@
         <%= link_to "Author",
           author_new_row_path,
           title: 'Add new Author',
-          remote: true,
+          remote: true, data: { turbo: false },
           tabindex: '-1'
         %>
       </li>
@@ -34,7 +34,7 @@
         <%= link_to "Reference",
           reference_new_row_path,
           title: 'Add a new reference',
-          remote: true,
+          remote: true, data: { turbo: false },
           tabindex: '-1'
         %>
       </li>
@@ -56,7 +56,7 @@
               <%= link_to "Accepted or excluded record",
                 loader_name_new_row_path,
                 {title: "Add a new accepted or excluded loader-name to batch #{session[:default_loader_batch_name]}",
-                remote: true,
+                remote: true, data: { turbo: false },
                 tabindex: '-1'}
               %>
             </li>
@@ -64,7 +64,7 @@
               <%= link_to "Heading",
                 loader_name_new_heading_row_path,
                 title: "Add a new heading loader-name record within batch #{session[:default_loader_batch_name]}",
-                remote: true,
+                remote: true, data: { turbo: false },
                 tabindex: '-1'
               %>
             </li>
@@ -72,7 +72,7 @@
               <%= link_to "Batch note",
                 loader_name_new_in_batch_note_row_path,
                 title: 'Add a new "in-batch-note" loader-name within the current loader-batch',
-                remote: true,
+                remote: true, data: { turbo: false },
                 tabindex: '-1'
               %>
             </li>
@@ -83,7 +83,7 @@
         <%= link_to "Loader Batch",
           loader_batch_new_row_path,
           {title: "Add a new loader batch",
-          remote: true,
+          remote: true, data: { turbo: false },
           tabindex: '-1'}
         %>
       </li>
@@ -93,7 +93,7 @@
           <%= link_to "User",
             user_new_row_path,
             title: 'Add User',
-            remote: true,
+            remote: true, data: { turbo: false },
             tabindex: '-1'
           %>
         </li>

--- a/app/views/layouts/_new_name_sub_menu.html.erb
+++ b/app/views/layouts/_new_name_sub_menu.html.erb
@@ -4,7 +4,7 @@
     <%= link_to "Scientific name",
                 name_new_row_path('scientific'),
                 title: 'Add a new scientific name',
-                remote: true,
+                remote: true, data: { turbo: false },
                 tabindex: '-1' %>
   </li>
 
@@ -12,7 +12,7 @@
     <%= link_to "Scientific name family or above",
                 name_new_row_path('scientific-family-or-above'),
                 title: 'Add a new scientific name family and above',
-                remote: true,
+                remote: true, data: { turbo: false },
                 tabindex: '-1' %>
   </li>
 
@@ -20,7 +20,7 @@
     <%= link_to "Phrase name",
                 name_new_row_path('phrase'),
                 title: 'Add a new phrase name',
-                remote: true,
+                remote: true, data: { turbo: false },
                 tabindex: '-1' %>
   </li>
 
@@ -29,14 +29,14 @@
     <%= link_to "Named Hybrid",
                 name_new_row_path('named-hybrid'),
                 title: 'Add a new named hybrid',
-                remote: true,
+                remote: true, data: { turbo: false },
                 tabindex: '-1' %>
   </li>
   <li role="presentation">
     <%= link_to "Hybrid formula name",
                 name_new_row_path('hybrid formula'),
                 title: 'Add a new hybrid name',
-                remote: true,
+                remote: true, data: { turbo: false },
                 tabindex: '-1' %>
   </li>
 
@@ -44,7 +44,7 @@
     <%= link_to "Hybrid formula unknown 2nd parent name",
                 name_new_row_path('hybrid-formula-unknown-2nd-parent'),
                 title: 'Add a new hybrid formula unknown 2nd parent name',
-                remote: true,
+                remote: true, data: { turbo: false },
                 tabindex: '-1' %>
   </li>
   <li role="presentation" class="divider"></li>
@@ -53,7 +53,7 @@
     <%= link_to "Cultivar hybrid name",
                 name_new_row_path('cultivar-hybrid'),
                 title: 'Add a new cultivar hybrid name',
-                remote: true,
+                remote: true, data: { turbo: false },
                 tabindex: '-1' %>
   </li>
 
@@ -61,7 +61,7 @@
     <%= link_to "Cultivar name",
                 name_new_row_path('cultivar'),
                 title: 'Add a new cultivar name',
-                remote: true,
+                remote: true, data: { turbo: false },
                 tabindex: '-1' %>
   </li>
 
@@ -71,7 +71,7 @@
     <%= link_to "Other name",
                 name_new_row_path('other'),
                 title: 'Add a new other name',
-                remote: true,
+                remote: true, data: { turbo: false },
                 tabindex: '-1' %>
   </li>
 <% elsif can?(:create_common_name, Name) %>
@@ -79,7 +79,7 @@
       <%= link_to "Other name",
                   name_new_row_path('other'),
                   title: 'Add a new other name',
-                  remote: true,
+                  remote: true, data: { turbo: false },
                   tabindex: '-1' %>
     </li>
 <% end %>

--- a/app/views/layouts/_taxonomy_menu.html.erb
+++ b/app/views/layouts/_taxonomy_menu.html.erb
@@ -27,7 +27,7 @@
                       tree_versions_edit_draft_path,
                       id: "edit-draft-taxonomy-menu-link-#{selected_draft_title.gsub(/ /,'-')}",
                       title: 'Edit draft taxonomy',
-                      remote: true,
+                      remote: true, data: { turbo: false },
                       tabindex: '-1' %>
         </li>
         <li>
@@ -35,7 +35,7 @@
                       tree_versions_form_to_publish_path,
                       id: "publish-draft-taxonomy-menu-link-#{selected_draft_title.gsub(/ /,'-')}",
                       title: 'Publish draft taxonomy',
-                      remote: true,
+                      remote: true, data: { turbo: false },
                       tabindex: '-1' %>
         </li>
       <% end %>
@@ -66,7 +66,7 @@
                             tree_versions_new_draft_path(tree.id),
                             id: 'create-draft-taxonomy-menu-link',
                             title: 'Add a new draft taxonomy',
-                            remote: true,
+                            remote: true, data: { turbo: false },
                             tabindex: '-1' %>
               </li>
             <% end %>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -81,7 +81,7 @@
         <%= link_to "<i class=''></i> Switch to Review Mode".html_safe,
                     switch_on_review_mode_path,
                     title: 'See things as a reviewer would',
-                    remote: true,
+                    remote: true, data: { turbo: false },
                     method: :post,
                     tabindex: '-1' %>
          <li role="presentation" class="divider"></li>
@@ -94,7 +94,7 @@
          <%= link_to "<i class=''></i> Switch out of Review Mode".html_safe,
                      switch_off_review_mode_path,
                      title: 'Stop seeing things as a reviewer would',
-                     remote: true,
+                     remote: true, data: { turbo: false },
                      method: :post,
                      tabindex: '-1' %>
          <li role="presentation" class="divider"></li>

--- a/app/views/loader/batch/bulk/_stats.html.erb
+++ b/app/views/loader/batch/bulk/_stats.html.erb
@@ -9,7 +9,7 @@
   <%= render partial: 'stats_table', locals: { a_hash: value } %>
   <% if key.downcase == :lock %>
     <% if Loader::Batch::Bulk::JobLock.locked? %>
-      <%= link_to "Emergency unlock batch jobs", {controller: 'job_lock', action: 'unlock'}, {id: 'emergency-unlock-link', class: 'btn btn-primary', remote: true, title: "Unlock the batch lock", method: :post} %>
+      <%= link_to "Emergency unlock batch jobs", {controller: 'job_lock', action: 'unlock'}, {id: 'emergency-unlock-link', class: 'btn btn-primary', remote: true, data: { turbo: false }, title: "Unlock the batch lock", method: :post} %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/loader/batch/bulk/job_already_locked_error.js.erb
+++ b/app/views/loader/batch/bulk/job_already_locked_error.js.erb
@@ -2,6 +2,6 @@ debug('job lock error');
 debug($('#bulk-operations-error-message-container').length);
 debug($('.message-container').length);
 debug($('.message-clearer').length);
-$('#bulk-operations-error-message-container').html("Processing is locked - perhaps there's another job running <br> If you're confident no-one else is running a bulk operation in the database, and you're not running one, you can clear the lock.<br><%= escape_javascript(link_to "Emergency unlock batch jobs", {controller: 'job_lock', action: 'unlock'}, {id: 'emergency-unlock-link', class: 'btn btn-primary', remote: true, title: "Unlock the batch lock", method: :post}) %>");
+$('#bulk-operations-error-message-container').html("Processing is locked - perhaps there's another job running <br> If you're confident no-one else is running a bulk operation in the database, and you're not running one, you can clear the lock.<br><%= escape_javascript(link_to "Emergency unlock batch jobs", {controller: 'job_lock', action: 'unlock'}, {id: 'emergency-unlock-link', class: 'btn btn-primary', remote: true, data: { turbo: false }, title: "Unlock the batch lock", method: :post}) %>");
 $('.message-clearer').removeClass('hidden');
 debug('job lock error reported');

--- a/app/views/loader/batch/review/periods/tabs/_tab_reviewers.html.erb
+++ b/app/views/loader/batch/review/periods/tabs/_tab_reviewers.html.erb
@@ -47,7 +47,7 @@
                                    class: "btn btn-danger pull-right",
                                    tabindex: increment_tab_index,
                                    title: "Confirm the delete.",
-                                   remote: true,
+                                   remote: true, data: { turbo: false },
                                    method: :delete)
               %>
 

--- a/app/views/loader/batch/review/periods/widgets/_delete_widgets.html.erb
+++ b/app/views/loader/batch/review/periods/widgets/_delete_widgets.html.erb
@@ -22,7 +22,7 @@
                                  class: "btn btn-danger confirm-delete-btn",
                                  tabindex: increment_tab_index,
                                  title: "Confirm you want to delete batch review period.",
-                                 remote: true,
+                                 remote: true, data: { turbo: false },
                                  method: :delete) %>
 
 

--- a/app/views/loader/batch/reviewers/forms/_delete_widgets.html.erb
+++ b/app/views/loader/batch/reviewers/forms/_delete_widgets.html.erb
@@ -20,7 +20,7 @@
                                    class: "btn btn-danger confirm-delete-btn hidden",
                                    tabindex: increment_tab_index,
                                    title: "Confirm the delete.",
-                                   remote: true,
+                                   remote: true, data: { turbo: false },
                                    method: :delete)
   %>
 

--- a/app/views/loader/batch/reviews/tabs/_tab_reviewers.html.erb
+++ b/app/views/loader/batch/reviews/tabs/_tab_reviewers.html.erb
@@ -52,7 +52,7 @@
                                    class: "btn btn-danger pull-right",
                                    tabindex: increment_tab_index,
                                    title: "Confirm the delete.",
-                                   remote: true,
+                                   remote: true, data: { turbo: false },
                                    method: :delete)
               %>
 

--- a/app/views/loader/batch/reviews/widgets/_delete_widgets.html.erb
+++ b/app/views/loader/batch/reviews/widgets/_delete_widgets.html.erb
@@ -22,7 +22,7 @@
                                  class: "btn btn-danger confirm-delete-btn",
                                  tabindex: increment_tab_index,
                                  title: "Confirm you want to delete batch review.",
-                                 remote: true,
+                                 remote: true, data: { turbo: false },
                                  method: :delete) %>
 
 

--- a/app/views/loader/batches/bulk/_batch_summary_stats.html.erb
+++ b/app/views/loader/batches/bulk/_batch_summary_stats.html.erb
@@ -1,10 +1,10 @@
 <br>
 <br>
   <%= link_to 'Batch Summary Counts', loader_batch_stats_path(session[:default_loader_batch_id]),
-    {id: 'show-loader-stats-btn', class: 'btn btn-primary', title: 'Show latest counts for the current batch', remote: true} %>
-  <%= link_to 'Hide', loader_hide_batch_stats_path, {id: 'hide-loader-stats-btn', class: 'btn btn-primary hidden', title: 'Hide the counts', remote: true} %>
+    {id: 'show-loader-stats-btn', class: 'btn btn-primary', title: 'Show latest counts for the current batch', remote: true, data: { turbo: false }} %>
+  <%= link_to 'Hide', loader_hide_batch_stats_path, {id: 'hide-loader-stats-btn', class: 'btn btn-primary hidden', title: 'Hide the counts', remote: true, data: { turbo: false }} %>
   <%= link_to 'Refresh', loader_batch_stats_path(session[:default_loader_batch_id]),
-    {id: 'refresh-loader-stats-btn', class: 'btn btn-primary hidden', title: 'Show latest counts for the current batch', remote: true} %>
+    {id: 'refresh-loader-stats-btn', class: 'btn btn-primary hidden', title: 'Show latest counts for the current batch', remote: true, data: { turbo: false }} %>
   <div id="batch-stats">
   </div>
 

--- a/app/views/loader/batches/bulk/_form.html.erb
+++ b/app/views/loader/batches/bulk/_form.html.erb
@@ -5,7 +5,7 @@ Directives available here: <code>family: [family name string]</code>,  <code>acc
 Wildcards are allowed but are <b>not</b> added automatically.<br>
 (Adding them automatically would stop you specifying non-wildcarded sets of names to process.)<br>
 The <code>family:</code> directive can take a comma-separated list of family names <em>without</em> wildcards
-<%= form_tag({controller: "loader/batch/bulk", action: "operation"}, method: "post", remote: true) do %>
+<%= form_tag({controller: "loader/batch/bulk", action: "operation"}, method: "post", remote: true, data: { turbo: false }) do %>
 
   <div class="width-64em">
     <input name="name_string"
@@ -41,13 +41,13 @@ The <code>family:</code> directive can take a comma-separated list of family nam
       <%= link_to "Enable Remove Syn Conflicts", 
         {controller: 'loader/batch/bulk', action: 'enable_delete_syn_conflict'},
         {id: 'enable-delete-syn-conflict', class: 'btn btn-primary width-16em',
-         remote: true, title: "Enable the Remove Syn Conflicts button",
+         remote: true, data: { turbo: false }, title: "Enable the Remove Syn Conflicts button",
          method: :post} %>
 
        <%= link_to "Disable Remove Syn Conflicts",
          {controller: 'loader/batch/bulk', action: 'disable_delete_syn_conflict'},
          {id: 'disable-delete-syn-conflict', class: 'btn btn-primary width-16em', style: 'display: none;',
-          remote: true, title: "Disable the Remove Syn Conficts button",
+          remote: true, data: { turbo: false }, title: "Disable the Remove Syn Conficts button",
           method: :post} %>
         <input id="delete-syn-conflicts-batch-submit"
                name="submit"
@@ -70,13 +70,13 @@ The <code>family:</code> directive can take a comma-separated list of family nam
       <%= link_to "Enable Add to draft taxonomy", 
         {controller: 'loader/batch/bulk', action: 'enable_add'},
         {id: 'enable-add', class: 'btn btn-primary width-16em',
-         remote: true, title: "Enable the Add to draft taxonomy button",
+         remote: true, data: { turbo: false }, title: "Enable the Add to draft taxonomy button",
          method: :post} %>
 
        <%= link_to "Disable Add to draft taxonomy",
          {controller: 'loader/batch/bulk', action: 'disable_add'},
          {id: 'disable-add', class: 'btn btn-primary width-16em', style: 'display: none;',
-          remote: true, title: "Disable the Add to draft taxonomy button",
+          remote: true, data: { turbo: false }, title: "Disable the Add to draft taxonomy button",
           method: :post} %>
       <input id="add-instances-to-draft-taxonomy-batch-submit"
              name="submit"
@@ -109,7 +109,7 @@ The <code>family:</code> directive can take a comma-separated list of family nam
 <div id="add-to-draft-taxonomy-info-message-container" class="message-container"></div>
 <div id="add-to-draft-taxonomy-error-message-container" class="error-container message-container"></div>
 <br>
-<%= link_to "[clear messages]", loader_batch_clear_path, class:"hidden message-clearer with-underline", remote: true, title: "Clear the messages" %> 
+<%= link_to "[clear messages]", loader_batch_clear_path, class:"hidden message-clearer with-underline", remote: true, data: { turbo: false }, title: "Clear the messages" %> 
 <br>
 <%= link_to "Recent logs", search_path(query_string: "latest:",query_target: 'bulk_processing_logs'), title: "See logs", class: "with-underline" %> 
 <br>
@@ -122,8 +122,8 @@ The <code>family:</code> directive can take a comma-separated list of family nam
 <div id="bulk-ops-stats-container" class="">
 </div>
 
-<%= link_to 'Bulk Operation Notes', loader_batch_bulk_processing_notes_path, {id: 'batch-processing-bulk-op-notes-btn', class: 'btn btn-primary', title: 'Show a summary overview of the loading process', remote: true} %>
-<%= link_to 'Hide', loader_batch_bulk_processing_notes_hide_path, {id: 'batch-processing-bulk-op-notes-hide-btn', class: 'btn btn-primary hidden', title: 'Hide the summary', remote: true} %>
+<%= link_to 'Bulk Operation Notes', loader_batch_bulk_processing_notes_path, {id: 'batch-processing-bulk-op-notes-btn', class: 'btn btn-primary', title: 'Show a summary overview of the loading process', remote: true, data: { turbo: false }} %>
+<%= link_to 'Hide', loader_batch_bulk_processing_notes_hide_path, {id: 'batch-processing-bulk-op-notes-hide-btn', class: 'btn btn-primary hidden', title: 'Hide the summary', remote: true, data: { turbo: false }} %>
 <div id="batch-processing-bulk-op-notes" class="hidden">
 <h5>Bulk Operation Notes</h5>
 

--- a/app/views/loader/batches/bulk/_overview.html.erb
+++ b/app/views/loader/batches/bulk/_overview.html.erb
@@ -1,5 +1,5 @@
-<%= link_to 'Overview', loader_batch_processing_overview_path, {id: 'batch-processing-overview-btn', class: 'btn btn-primary', title: 'Show a summary overview of the loading process', remote: true} %>
-<%= link_to 'Hide', loader_batch_processing_overview_hide_path, {id: 'batch-processing-overview-hide-btn', class: 'btn btn-primary hidden', title: 'Hide the summary', remote: true} %>
+<%= link_to 'Overview', loader_batch_processing_overview_path, {id: 'batch-processing-overview-btn', class: 'btn btn-primary', title: 'Show a summary overview of the loading process', remote: true, data: { turbo: false }} %>
+<%= link_to 'Hide', loader_batch_processing_overview_hide_path, {id: 'batch-processing-overview-hide-btn', class: 'btn btn-primary hidden', title: 'Hide the summary', remote: true, data: { turbo: false }} %>
 <div id="batch-processing-overview" class="hidden">
 Batch data is imported (from parsed Word documents) as <code>loader-name</code> records
 <h5>Steps</h5>

--- a/app/views/loader/batches/tabs/_set_default_batch.html.erb
+++ b/app/views/loader/batches/tabs/_set_default_batch.html.erb
@@ -19,10 +19,10 @@
               {class: 'blue', 
                title: 'Make this the default batch for queries', 
                method: :post, 
-               remote: true}) %>
+               remote: true, data: { turbo: false }}) %>
   <% end %>
   <br>
-  <%= link_to("Clear the default batch",clear_default_batch_path,{class: 'blue', title: 'Clear out the default batch setting for queries', method: :post, remote: true}) %>
+  <%= link_to("Clear the default batch",clear_default_batch_path,{class: 'blue', title: 'Clear out the default batch setting for queries', method: :post, remote: true, data: { turbo: false }}) %>
 <% else %>
   There is no default batch.  Loader Name queries can be for any batch.
   <br>
@@ -32,7 +32,7 @@
               {class: 'blue', 
                title: 'Make this the default batch for queries', 
                method: :post, 
-               remote: true}) %>
+               remote: true, data: { turbo: false }}) %>
 <% end %>
 <br>
 <%= divider %>

--- a/app/views/loader/batches/tabs/_tab_ordering.html.erb
+++ b/app/views/loader/batches/tabs/_tab_ordering.html.erb
@@ -22,17 +22,17 @@
   <br>
   <br>
   <%= button_to "Multiply all seq by 10", loader_batch_prep_multiply_seqs_by_10_path, 
-    id: 'prep-multiply', remote: true, class: 'btn btn-warning width-15em pull-right',
+    id: 'prep-multiply', remote: true, data: { turbo: false }, class: 'btn btn-warning width-15em pull-right',
     title: 'Click here to multiply all sequence numbers by 10' %>
   <br>
   <br>
   <%= button_to "Confirm multiply all seq by 10", loader_batch_multiply_seqs_by_10_path, 
-      id: 'confirm-multiply', remote: true, class: 'btn btn-danger width-15em hidden pull-right',
+      id: 'confirm-multiply', remote: true, data: { turbo: false }, class: 'btn btn-danger width-15em hidden pull-right',
       title: 'Click here to confirm you want to multiply all sequence numbers by 10' %>
   <br>
   <br>
   <%= button_to "Cancel", loader_batch_cancel_multiply_seqs_by_10_path, 
-      id: 'cancel-multiply', remote: true, class: 'btn btn-default width-5em hidden cancel-link pull-right',
+      id: 'cancel-multiply', remote: true, data: { turbo: false }, class: 'btn btn-default width-5em hidden cancel-link pull-right',
       title: 'Click here to cancel the multiply action' %>
   <br>
 

--- a/app/views/loader/batches/tabs/delete/_widgets.html.erb
+++ b/app/views/loader/batches/tabs/delete/_widgets.html.erb
@@ -23,7 +23,7 @@
                                  class: "btn btn-danger delete-widget",
                                  tabindex: increment_tab_index,
                                  title: "Confirm you want to delete the loader batch.",
-                                 remote: true,
+                                 remote: true, data: { turbo: false },
                                  method: :delete)
 %>
 

--- a/app/views/loader/batches/tabs/ordering/_sort_key_ordering.html.erb
+++ b/app/views/loader/batches/tabs/ordering/_sort_key_ordering.html.erb
@@ -8,17 +8,17 @@ Warning: this will reset the <code>sort_key</code> for all synonym records in th
 <br>
 <br>
   <%= button_to "Refresh synonym sort key values", loader_batch_prep_refresh_syn_sort_key_path, 
-    id: 'prep-refresh', remote: true, class: 'btn btn-warning width-20em pull-right',
+    id: 'prep-refresh', remote: true, data: { turbo: false }, class: 'btn btn-warning width-20em pull-right',
     title: 'Click here to refresh all synonym sort key values' %>
   <br>
   <br>
   <%= button_to "Confirm refresh synonym sort key values", loader_batch_refresh_syn_sort_key_path, 
-      id: 'confirm-refresh', remote: true, class: 'btn btn-danger width-20em hidden pull-right',
+      id: 'confirm-refresh', remote: true, data: { turbo: false }, class: 'btn btn-danger width-20em hidden pull-right',
       title: 'Click here to confirm you want to refresh all synonym sort_key values' %>
   <br>
   <br>
   <%= button_to "Cancel refresh action", loader_batch_cancel_refresh_syn_sort_key_path, 
-      id: 'cancel-refresh', remote: true, class: 'btn btn-default width-20em hidden cancel-link pull-right',
+      id: 'cancel-refresh', remote: true, data: { turbo: false }, class: 'btn btn-default width-20em hidden cancel-link pull-right',
       title: 'Click here to cancel the refresh action' %>
   <br>
 

--- a/app/views/loader/name/review/comments/_edit_form.html.erb
+++ b/app/views/loader/name/review/comments/_edit_form.html.erb
@@ -24,7 +24,7 @@
       <br>
       <%= form.submit id: "save-new-batch-review-comment-btn", class: 'btn btn-primary', title: "Save comment", tabindex: increment_tab_index %>
       
-      <%= link_to 'Cancel', cancel_edit_name_review_comment_path(@review_comment.id), remote: true, class: 'btn btn-primary', title: 'Cancel the edit - remove the editing fields.' %>
+      <%= link_to 'Cancel', cancel_edit_name_review_comment_path(@review_comment.id), remote: true, data: { turbo: false }, class: 'btn btn-primary', title: 'Cancel the edit - remove the editing fields.' %>
         <span id="comment-<%= @review_comment.id %>-delete-widgets-container"> 
 
           <%= render partial: "loader/names/review/tabs/common/delete_dialog_button",

--- a/app/views/loader/names/review/tabs/common/_delete_dialog.html.erb
+++ b/app/views/loader/names/review/tabs/common/_delete_dialog.html.erb
@@ -4,7 +4,7 @@
           dialog_to_delete_name_review_comment_path(comment.id),
           method: :delete,
           disabled: true,
-          remote: true,
+          remote: true, data: { turbo: false },
           class: 'btn btn-warning pull-right',
           title: 'Prepare to delete this comment' %>
 
@@ -12,13 +12,13 @@
         <%= link_to 'Cancel delete',
           cancel_dialog_to_delete_name_review_comment_path(comment.id),
           method: :get,
-          remote: true,
+          remote: true, data: { turbo: false },
           class: 'btn btn-default pull-right',
           title: 'Cancel your intention to delete this comment' %>
 
         <%= link_to 'Confirm delete',
           delete_name_review_comment_path(comment.id),
           method: :delete,
-          remote: true,
+          remote: true, data: { turbo: false },
           class: 'btn btn-danger pull-right',
           title: 'Really delete the comment' %>

--- a/app/views/loader/names/review/tabs/common/_delete_dialog_button.html.erb
+++ b/app/views/loader/names/review/tabs/common/_delete_dialog_button.html.erb
@@ -1,7 +1,7 @@
         <%= link_to 'Delete...',
           dialog_to_delete_name_review_comment_path(comment.id),
           method: :delete,
-          remote: true,
+          remote: true, data: { turbo: false },
           class: 'btn btn-warning pull-right',
           title: 'Prepare to delete this comment' %>
 

--- a/app/views/loader/names/review/tabs/common/_one_comment.html.erb
+++ b/app/views/loader/names/review/tabs/common/_one_comment.html.erb
@@ -15,7 +15,7 @@
                       info: 
                       "#{comment.reviewer.user.full_name} (#{comment.reviewer.org.try('abbrev')} #{comment.reviewer.role.name})
                        #{link_to('(edit)', edit_name_review_comment_path(comment.id),
-                                           remote: true,
+                                           remote: true, data: { turbo: false },
                                            class: 'blue',
                                            title: 'Edit your comment') if comment.batch_review_period.active? && 
                                                                           @current_user.username == comment.reviewer.user.user_name} "}

--- a/app/views/loader/names/review/tabs/main/votes/votable/voting_in_progress/can_vote/not_heading/vote/_delete_widgets.html.erb
+++ b/app/views/loader/names/review/tabs/main/votes/votable/voting_in_progress/can_vote/not_heading/vote/_delete_widgets.html.erb
@@ -13,7 +13,7 @@
               delete_name_review_vote_path(vote.loader_name_id, vote.batch_review_id, vote.org_id),
               class: "btn btn-danger confirm-delete-btn",
               title: "Confirm you want to delete the vote.",
-              remote: true,
+              remote: true, data: { turbo: false },
               method: :delete)
   %>
 

--- a/app/views/loader/names/tabs/_delete_widgets.html.erb
+++ b/app/views/loader/names/tabs/_delete_widgets.html.erb
@@ -22,7 +22,7 @@
                                  class: "btn btn-danger confirm-delete-btn delete-widget",
                                  tabindex: increment_tab_index,
                                  title: "Confirm you want to delete the loader name.",
-                                 remote: true,
+                                 remote: true, data: { turbo: false },
                                  method: :delete)
 %>
 

--- a/app/views/loader/names/tabs/delete/_force_delete_widgets.html.erb
+++ b/app/views/loader/names/tabs/delete/_force_delete_widgets.html.erb
@@ -13,7 +13,7 @@
                                  class: "btn btn-danger delete-widget",
                                  tabindex: increment_tab_index,
                                  title: "Confirm you want to force-delete the loader name.",
-                                 remote: true,
+                                 remote: true, data: { turbo: false },
                                  method: :delete)
 %>
 

--- a/app/views/loader/names/tabs/details/matches/accepted_names/forms/_preferred_matches.html.erb
+++ b/app/views/loader/names/tabs/details/matches/accepted_names/forms/_preferred_matches.html.erb
@@ -4,7 +4,7 @@
              as: 'loader_name',
              url: loader_name_matches_set_path,
              role: 'form',
-             remote: true) do |form| %>
+             remote: true, data: { turbo: false }) do |form| %>
 
   <% @loader_name.matches(type: match_type)
                  .each_with_index do |matching_name, index| %>

--- a/app/views/loader/names/tabs/details/matches/excluded_names/forms/_clear_all_matches.html.erb
+++ b/app/views/loader/names/tabs/details/matches/excluded_names/forms/_clear_all_matches.html.erb
@@ -1,5 +1,5 @@
 <% if @loader_name.can_clear_matches? %>
-    <%= form_with(url: loader_name_matches_delete_all_path, role: 'form', remote: true, method: :delete) do |f| -%>
+    <%= form_with(url: loader_name_matches_delete_all_path, role: 'form', remote: true, data: { turbo: false }, method: :delete) do |f| -%>
       <%= f.hidden_field(:id, value: @loader_name.id) -%>
       <%= f.submit "Clear the matches", id: 'clear-matches', tabindex: increment_tab_index,
         title: 'Clear all matches', class: 'btn btn-primary width-15em "#{$q(hidden) unless @loader_name.matches.empty?}"' -%>

--- a/app/views/loader/names/tabs/details/matches/excluded_names/forms/_preferred_matches.html.erb
+++ b/app/views/loader/names/tabs/details/matches/excluded_names/forms/_preferred_matches.html.erb
@@ -4,7 +4,7 @@
              as: 'loader_name',
              url: loader_name_matches_set_path,
              role: 'form',
-             remote: true) do |form| %>
+             remote: true, data: { turbo: false }) do |form| %>
 
   <% @loader_name.matches(type: match_type)
                  .each_with_index do |matching_name, index| %>

--- a/app/views/loader/names/tabs/details/matches/misapplieds/_unsourced_preferred_matches.html.erb
+++ b/app/views/loader/names/tabs/details/matches/misapplieds/_unsourced_preferred_matches.html.erb
@@ -4,7 +4,7 @@
              as: 'loader_name',
              url: loader_name_matches_set_path,
              role: 'form',
-             remote: true) do |form| %>
+             remote: true, data: { turbo: false }) do |form| %>
 
   <% @loader_name.matches(type: :strict)
                  .each_with_index do |matching_name, index| %>

--- a/app/views/loader/names/tabs/details/matches/synonyms/forms/_preferred_matches.html.erb
+++ b/app/views/loader/names/tabs/details/matches/synonyms/forms/_preferred_matches.html.erb
@@ -4,7 +4,7 @@
              as: 'loader_name',
              url: loader_name_matches_set_path,
              role: 'form',
-             remote: true) do |form| %>
+             remote: true, data: { turbo: false }) do |form| %>
 
   <% @loader_name.matches(type: match_type)
                  .each do |matching_name | %>

--- a/app/views/loader/names/tabs/in_batch_note_record_tabs/_delete_widgets.html.erb
+++ b/app/views/loader/names/tabs/in_batch_note_record_tabs/_delete_widgets.html.erb
@@ -21,7 +21,7 @@
                                  class: "btn btn-danger confirm-delete-btn delete-widget",
                                  tabindex: increment_tab_index,
                                  title: "Confirm you want to delete the loader name.",
-                                 remote: true,
+                                 remote: true, data: { turbo: false },
                                  method: :delete)
 %>
 

--- a/app/views/loader/names/tabs/matched_name/_clear_intended_parent.html.erb
+++ b/app/views/loader/names/tabs/matched_name/_clear_intended_parent.html.erb
@@ -1,4 +1,4 @@
-        <%= form_for(preferred_match, as: 'loader_name_match', role: 'form', remote: true) do |f| %>
+        <%= form_for(preferred_match, as: 'loader_name_match', role: 'form', remote: true, data: { turbo: false }) do |f| %>
 
           <%= f.submit "Clear Intended Parent",
                        id: 'clear-loader-name-intended-tree-instance-id',

--- a/app/views/loader/names/tabs/matched_name/_drafted.html.erb
+++ b/app/views/loader/names/tabs/matched_name/_drafted.html.erb
@@ -17,7 +17,7 @@
          <br> 
          <%= link_to "Verify drafted flag", loader_name_matches_verify_drafted_path(preferred_match),
              title: "Verify drafted flag is correct - tree work outside the loader may not be detected",
-             class: 'blue', method: :patch, remote: true %>
+             class: 'blue', method: :patch, remote: true, data: { turbo: false } %>
           <span id="verify-drafted-info-message-container" class="message-container"></span>
        <% end %>
        </br>
@@ -37,7 +37,7 @@
         <% end %>
       <% else %>
         This loader-name is not manually drafted.
-        <%= form_for(@loader_name.loader_name_matches.first, as: 'loader-name', role: 'form', remote: true) do |f| %>
+        <%= form_for(@loader_name.loader_name_matches.first, as: 'loader-name', role: 'form', remote: true, data: { turbo: false }) do |f| %>
           <%= f.hidden_field(:loader_name_match_id, value: @loader_name.loader_name_matches.first.id) %>
           <%= f.submit "Flag it as manually drafted", id: 'save-loader-name-manually-drafted', tabindex: increment_tab_index, title: 'Flag as manually drafted', class: 'btn btn-primary width-15em', disabled: false %>
         <% end %>

--- a/app/views/loader/names/tabs/matched_name/_force_remove.html.erb
+++ b/app/views/loader/names/tabs/matched_name/_force_remove.html.erb
@@ -12,17 +12,17 @@
     <br>
     Removing it will destroy the history of processing.
     <%= button_to "Remove match", loader_name_matches_prepare_force_remove_path(match.id),
-      remote: true,
+      remote: true, data: { turbo: false },
       id: "prepare_force_remove_btn_#{match.id}",
       class: 'btn btn-warning width-10em pull-right',
       title: 'Click here to remove the match' %>
     <%= button_to "Cancel Remove", loader_name_matches_cancel_force_remove_path(match.id),
-      remote: true,
+      remote: true, data: { turbo: false },
       id: "cancel_force_remove_btn_#{match.id}",
       class: 'hidden btn btn-default width-10em pull-right',
       title: 'Click here to remove the match' %>
     <%= button_to "Confirm Remove", loader_name_matches_force_remove_path(match.id),
-      remote: true,
+      remote: true, data: { turbo: false },
       id: "force_remove_btn_#{match.id}",
       method: :delete,
       class: 'hidden btn btn-danger width-12em pull-right',

--- a/app/views/loader/names/tabs/matched_name/_intended_parent.html.erb
+++ b/app/views/loader/names/tabs/matched_name/_intended_parent.html.erb
@@ -14,7 +14,7 @@
     <% else %>
         Name parent: <%= preferred_match.name.parent.full_name %>
         <br/>
-        <%= form_for(preferred_match, as: 'loader_name_match', role: 'form', remote: true) do |f| %>
+        <%= form_for(preferred_match, as: 'loader_name_match', role: 'form', remote: true, data: { turbo: false }) do |f| %>
 
           <div class="typeahead-container">
             <section class='block width-100-percent'>

--- a/app/views/loader/names/tabs/matched_name/_preferred.html.erb
+++ b/app/views/loader/names/tabs/matched_name/_preferred.html.erb
@@ -12,7 +12,7 @@
   <% unless @loader_name.accepted? || @loader_name.excluded? %>
     Instance type: <%= loader_name_match.instance.instance_type.name %><br>
 
-      <%= form_for(loader_name_match, as: 'loader_name_match', role: 'form', remote: true) do |f| %>
+      <%= form_for(loader_name_match, as: 'loader_name_match', role: 'form', remote: true, data: { turbo: false }) do |f| %>
         
       Relationship instance type: 
         <%= f.select(:relationship_instance_type_id,

--- a/app/views/loader/names/tabs/ref_instance/accepted_or_excluded_names/_copy_and_append_form.html.erb
+++ b/app/views/loader/names/tabs/ref_instance/accepted_or_excluded_names/_copy_and_append_form.html.erb
@@ -4,7 +4,7 @@
                 data: { turbo: false },
                 local: false)  do |form| %>
     <div> Choose an instance
-    <%= form.submit "Save", remote: true, class: 'width-5em btn btn-primary pull-right', title: 'Save your choice.' %>
+    <%= form.submit "Save", remote: true, data: { turbo: false }, class: 'width-5em btn btn-primary pull-right', title: 'Save your choice.' %>
     </div>
     <%= form.hidden_field :id %>
     <%= form.hidden_field :use_batch_default_reference, value: false %>
@@ -52,7 +52,7 @@
     <% end %>
     </table>
       <br>
-    <%= form.submit "Save", remote: true, class: 'width-5em btn btn-primary pull-left', title: 'Save your choice.' %>
+    <%= form.submit "Save", remote: true, data: { turbo: false }, class: 'width-5em btn btn-primary pull-left', title: 'Save your choice.' %>
 <% end %>
 
 

--- a/app/views/loader/names/tabs/ref_instance/accepted_or_excluded_names/_use_batch_default_ref_form.html.erb
+++ b/app/views/loader/names/tabs/ref_instance/accepted_or_excluded_names/_use_batch_default_ref_form.html.erb
@@ -6,7 +6,7 @@
     <%= form.hidden_field :id %>
       <br>
       Confirm your choice to <b>use the batch default reference</b> for this record:
-      <%= form.submit "Confirm", remote: true, class: 'width-5em btn btn-primary pull-right',
+      <%= form.submit "Confirm", remote: true, data: { turbo: false }, class: 'width-5em btn btn-primary pull-right',
              title: 'Confirm Use batch default referene.' %>
       <br>
       <br>

--- a/app/views/loader/names/tabs/ref_instance/accepted_or_excluded_names/_use_existing_instance_form.html.erb
+++ b/app/views/loader/names/tabs/ref_instance/accepted_or_excluded_names/_use_existing_instance_form.html.erb
@@ -4,7 +4,7 @@
                 data: { turbo: false },
                 local: false)  do |form| %>
     <div> Choose an instance
-    <%= form.submit "Save", remote: true, class: 'width-5em btn btn-primary pull-right', title: 'Save your choice.' %>
+    <%= form.submit "Save", remote: true, data: { turbo: false }, class: 'width-5em btn btn-primary pull-right', title: 'Save your choice.' %>
     </div>
     <div id="search-result-details-info-message-container-top" class="message-container"></div>
     <div id="search-result-details-error-message-container-top" class="error-container"></div>
@@ -47,5 +47,5 @@
     <% end %>
     </table>
       <br>
-    <%= form.submit "Save", remote: true, class: 'width-5em btn btn-primary pull-left', title: 'Save your choice.' %>
+    <%= form.submit "Save", remote: true, data: { turbo: false }, class: 'width-5em btn btn-primary pull-left', title: 'Save your choice.' %>
 <% end %>

--- a/app/views/loader/names/tabs/rev_comments/_one_comment.html.erb
+++ b/app/views/loader/names/tabs/rev_comments/_one_comment.html.erb
@@ -15,7 +15,7 @@
                       info: 
                       "#{comment.reviewer.user.full_name} (#{comment.reviewer.org.try('abbrev')} #{comment.reviewer.role.name})
                        #{link_to('(edit)', edit_name_review_comment_path(comment.id, :offer_context),
-                                           remote: true,
+                                           remote: true, data: { turbo: false },
                                            class: 'blue',
                                            title: 'Edit your comment') if @current_user.username == comment.reviewer.user.user_name} "}
                     %>

--- a/app/views/name_tag_names/_delete_widgets.html.erb
+++ b/app/views/name_tag_names/_delete_widgets.html.erb
@@ -14,7 +14,7 @@
                                  class: "btn btn-danger confirm-delete-btn",
                                  title: "Really removes the tag.",
                                  tabindex: increment_tab_index,
-                                 remote: true,
+                                 remote: true, data: { turbo: false },
                                  method: :delete)
 %>
 

--- a/app/views/name_tag_names/_form.html.erb
+++ b/app/views/name_tag_names/_form.html.erb
@@ -1,6 +1,6 @@
 <% name_tag_name = name.name_tag_names.new %>
 
-<%= form_for(name_tag_name, remote: true) do |f| %>
+<%= form_for(name_tag_name, remote: true, data: { turbo: false }) do |f| %>
   <%= f.hidden_field(:name_id, value: name_tag_name.name_id) %>
   <div class="form-group">
     <label for="name_tag_name_tag_id">Tag*</label>

--- a/app/views/names/de_duplicates/_index.html.erb
+++ b/app/views/names/de_duplicates/_index.html.erb
@@ -28,7 +28,7 @@
     <li><%= pluralize(Name.children_of_duplicates_count,'child') %>
     <%= link_to 'Transfer all children from duplicate to master',
                 name_transfer_all_dependents_path('children'),
-                method: :post, remote: true, class: "button",
+                method: :post, remote: true, data: { turbo: false }, class: "button",
                 title: "Transfer dependents to the master record",
                 onclick: "$('#all-dep-info-message-container').html('Working'); return true;"
           %>
@@ -38,7 +38,7 @@
     <li><%= pluralize(Name.instances_of_duplicates_count,'instance') %>
     <%= link_to 'Transfer all instances from duplicate to master',
                 name_transfer_all_dependents_path('instances'),
-                method: :post, remote: true, class: "button",
+                method: :post, remote: true, data: { turbo: false }, class: "button",
                 title: "Transfer dependents to the master record",
                 onclick: "$('#all-dep-info-message-container').html('Working'); return true;"
           %>
@@ -48,7 +48,7 @@
     <li><%= pluralize(Name.family_members_of_duplicates_count,'family member') %>
     <%= link_to 'Transfer all family members from duplicate to master',
                 name_transfer_all_dependents_path('in_family'),
-                method: :post, remote: true, class: "button",
+                method: :post, remote: true, data: { turbo: false }, class: "button",
                 title: "Transfer dependents to the master record",
                 onclick: "$('#all-dep-info-message-container').html('Working'); return true;"
           %>

--- a/app/views/names/de_duplication/_index.html.erb
+++ b/app/views/names/de_duplication/_index.html.erb
@@ -20,7 +20,7 @@
           <%= link_to 'transfer',
             name_transfer_dependents_path(@name.id,key.to_s),
             method: :post,
-            remote: true,
+            remote: true, data: { turbo: false },
             class: "bgorange white btn-slim",
             title: "Transfer dependents to the master record",
             onclick: "$('#de-duplicate-info-message-container').html('Working'); return true;"

--- a/app/views/names/form/_base.html.erb
+++ b/app/views/names/form/_base.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(@name, as: 'name', role: 'form', remote: true) do |f| %>
+<%= form_for(@name, as: 'name', role: 'form', remote: true, data: { turbo: false }) do |f| %>
   <%= render partial: "names/form/title" if @name.id.present? -%>
   <input type="hidden" name="random_id" value="<%= params[:random_id] %>"/>
   <input type="hidden" name="category" value="<%= params[:category] %>"/>

--- a/app/views/names/form/_copy.html.erb
+++ b/app/views/names/form/_copy.html.erb
@@ -14,7 +14,7 @@
                     role: 'form',
                     remote: true,
                     method: :post,
-                    data: copy_form_data}) do |f| %>
+                    data: copy_form_data.merge(turbo: false)}) do |f| %>
  <% if @name.errors.any? %>
     <div id="error_explanation">
       <h6><%= pluralize(@name.errors.count, "error") %> prohibited this name from being saved:</h6>

--- a/app/views/names/form/_copy_instances.html.erb
+++ b/app/views/names/form/_copy_instances.html.erb
@@ -3,7 +3,7 @@
              url: name_copy_instances_path(id: @name.id),
              html: {id: "copy-name-form",
                     role: 'form',
-                    remote: true,
+                    remote: true, data: { turbo: false },
                     method: :post}) do |f| %>
  <% if @name.errors.any? %>
     <div id="error_explanation">

--- a/app/views/names/name_resources/_add_resource_form.html.erb
+++ b/app/views/names/name_resources/_add_resource_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: name_name_resources_path(name), method: :post, remote: true do |f| %>
+<%= form_with url: name_name_resources_path(name), method: :post, remote: true, data: { turbo: false } do |f| %>
   <div id="add-resource-form-container" class="resource-edit-form hidden">
     <%= hidden_field_tag 'name_resource[resource_host_id]', '', id: 'resource-host-id-hidden' %>
     <div class="resource-form-grid">

--- a/app/views/names/name_resources/_edit_resource_form.html.erb
+++ b/app/views/names/name_resources/_edit_resource_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: name_name_resource_path(name, name_resource), method: :put, remote: true do |f| %>
+<%= form_with url: name_name_resource_path(name, name_resource), method: :put, remote: true, data: { turbo: false } do |f| %>
   <div id="resource-edit-form-<%= name_resource.id%>" class="resource-edit-form hidden">
     <%= hidden_field_tag 'name_resource[resource_host_id]', name_resource.resource_host_id %>
     <div class="resource-form-grid">

--- a/app/views/names/refresh/_widgets.html.erb
+++ b/app/views/names/refresh/_widgets.html.erb
@@ -12,7 +12,7 @@
   <div class="width-100-percent"> 
 
   <div id="confirm-or-cancel-refresh-link-container" class="confirm-or-cancel-link hidden">
-    <%= link_to "Confirm", refresh_name_path(@name.id), remote: true, class: 'btn btn-warning', title: "Confirm refresh." %>
+    <%= link_to "Confirm", refresh_name_path(@name.id), remote: true, data: { turbo: false }, class: 'btn btn-warning', title: "Confirm refresh." %>
     <%= link_to("Cancel",
                '#',
                id: "cancel-refresh-link",

--- a/app/views/names/refresh_children/_widgets.html.erb
+++ b/app/views/names/refresh_children/_widgets.html.erb
@@ -14,7 +14,7 @@
     <%= link_to "Confirm", 
       refresh_children_name_path(@name.id), 
       id: 'confirm-name-refresh-children-button', 
-      remote: true, 
+      remote: true, data: { turbo: false }, 
       method: :post,
       tabindex: increment_tab_index,
       class: 'btn btn-warning', 

--- a/app/views/names/refresh_name_path/_widgets.html.erb
+++ b/app/views/names/refresh_name_path/_widgets.html.erb
@@ -3,7 +3,7 @@
               id: "name-refresh-name-path-link",
               class: "btn btn-primary pull-right",
               title: "Refresh name path.",
-              remote: true,
+              remote: true, data: { turbo: false },
               method: :post,
               tabindex: increment_tab_index)
    %>

--- a/app/views/names/tabs/_tab_instances_profile_v2.html.erb
+++ b/app/views/names/tabs/_tab_instances_profile_v2.html.erb
@@ -19,7 +19,7 @@
     <div id="search-result-details-error-message-container-3" class="error-container"></div>
     <h5>Add an instance for <%= product.name %></h5>
 
-    <%= form_for(@instance, remote: true) do |f| %>
+    <%= form_for(@instance, remote: true, data: { turbo: false }) do |f| %>
       The new instance will remain attached to:<br>
 
       <h6>&mdash; <%= @instance.name.full_name %></h6>

--- a/app/views/names/widgets/_soft_delete_widgets.html.erb
+++ b/app/views/names/widgets/_soft_delete_widgets.html.erb
@@ -27,7 +27,7 @@
                                   class: "btn btn-danger confirm-soft-delete-btn",
                                   tabindex: increment_tab_index,
                                   title: "Confirm the soft delete.",
-                                  remote: true,
+                                  remote: true, data: { turbo: false },
                                   method: :post)
 -%>
 

--- a/app/views/names_deletes/_new.html.erb
+++ b/app/views/names_deletes/_new.html.erb
@@ -14,7 +14,7 @@
                         as: 'names_delete',
                         role: 'form',
                         method: :delete,
-                        remote: true}) do |f| %>
+                        remote: true, data: { turbo: false }}) do |f| %>
     <br>
     <%= f.hidden_field :name_id %>
     <%= f.submit "Confirm delete", 

--- a/app/views/profile_item_annotations/_form.html.erb
+++ b/app/views/profile_item_annotations/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: url, method: method, remote: true, html: { class: "prompt-form-save", data: { type: :json, form_type: 'annotation_form' } } do |f| %>
+<%= form_with url: url, method: method, remote: true, data: { turbo: false }, html: { class: "prompt-form-save", data: { type: :json, form_type: 'annotation_form' } } do |f| %>
   <div style="margin-top: 10px; display: flex; align-items: flex-start; gap: 8px;">
     <%= hidden_field_tag "profile_item_annotation[profile_item_id]", profile_item_annotation.profile_item_id %>
     <div style="flex: 1;">

--- a/app/views/profile_item_references/_annotation_form.html.erb
+++ b/app/views/profile_item_references/_annotation_form.html.erb
@@ -1,6 +1,6 @@
 <div style="padding-bottom: 20px;" id="edit_reference_<%= profile_item_reference.profile_item_id_reference_id %>">
   <% field_id = "#{profile_item.id}-#{profile_item_reference.profile_item_id_reference_id}" %>
-  <%= form_with model: profile_item_reference, url: save_profile_item_references_path(profile_item_reference.profile_item_id, profile_item_reference.reference_id), method: :put, remote: true, html: { data: { type: :json, form_type: 'reference_item_form' }, class: 'prompt-form-save' } do |f| %>
+  <%= form_with model: profile_item_reference, url: save_profile_item_references_path(profile_item_reference.profile_item_id, profile_item_reference.reference_id), method: :put, remote: true, data: { turbo: false }, html: { data: { type: :json, form_type: 'reference_item_form' }, class: 'prompt-form-save' } do |f| %>
     <div id="edit_reference_annotation_message_<%= profile_item_reference.profile_item_id_reference_id %>" class="message-container"><%= message if defined?(message) %></div>
     <label>Annotation:</label>
     <div style="display: flex">

--- a/app/views/profile_item_references/_form.html.erb
+++ b/app/views/profile_item_references/_form.html.erb
@@ -1,5 +1,5 @@
 <% field_id = profile_item_reference.persisted? ? "#{profile_item.id}-#{profile_item_reference.profile_item_id_reference_id}" : profile_item.id %>
-<%= form_with model: profile_item_reference, url: url, method: method, remote: true, html: { data: { type: :json, form_type: 'reference_item_form' }, class: 'prompt-form-save' } do |f| %>
+<%= form_with model: profile_item_reference, url: url, method: method, remote: true, data: { turbo: false }, html: { data: { type: :json, form_type: 'reference_item_form' }, class: 'prompt-form-save' } do |f| %>
   <!-- Hidden fields with parameters -->
   <%= hidden_field_tag "profile_item_reference[profile_item_id]", profile_item.id %>
   <%= hidden_field_tag "profile_item_reference[reference_id]", profile_item_reference.reference_id, id: "reference-id-hidden-#{field_id}" %>

--- a/app/views/profile_items/_fact_profile_item.html.erb
+++ b/app/views/profile_items/_fact_profile_item.html.erb
@@ -20,7 +20,7 @@
     </div>
 
     <% if profile_item.persisted? && profile_item.draft_version? %>
-      <%= form_with url: profile_items_publishes_path, method: :post, remote: true, html: { style: 'display:inline; margin-left:10px;', class: 'prompt-form-save always-prompt-before-action'  } do |f| %>
+      <%= form_with url: profile_items_publishes_path, method: :post, remote: true, data: { turbo: false }, html: { style: 'display:inline; margin-left:10px;', class: 'prompt-form-save always-prompt-before-action'  } do |f| %>
         <%= hidden_field_tag :id, profile_item.id %>
         <%= hidden_field_tag :instance_id, instance.id %>
         <%= submit_tag  'Publish', title: "Publish", class: 'btn btn-success', style: 'font-size: 12px; padding: 2px 8px;' %>

--- a/app/views/profile_texts/_form.html.erb
+++ b/app/views/profile_texts/_form.html.erb
@@ -1,6 +1,6 @@
 <% text_area_class = Rails.configuration.try('profile_v2_dropdown_ui') ? "editor-textarea-version2" : "editor-textarea" %>
 
-<%= form_with(model: profile_text, url: url, method: method, remote: true, html: { data: {type: 'json', form_type: 'profile_text_form' }, class: 'prompt-form-save' }) do |f| %>
+<%= form_with(model: profile_text, url: url, method: method, remote: true, data: { turbo: false }, html: { data: {type: 'json', form_type: 'profile_text_form' }, class: 'prompt-form-save' }) do |f| %>
   <%= hidden_field_tag "profile_item[id]", profile_item.id %>
   <%= hidden_field_tag "profile_item[instance_id]", instance_id %>
   <%= hidden_field_tag "profile_item[product_item_config_id]", product_item_config.id %>

--- a/app/views/references/_form.html.erb
+++ b/app/views/references/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_for(@reference,
              as: 'reference',
-             role: 'form', remote: true) do |f| %>
+             role: 'form', remote: true, data: { turbo: false }) do |f| %>
  <% if @reference.errors.any? %>
     <div id="error_explanation" class="red">
       <h6><%= pluralize(@reference.errors.count, "error") %> prohibited this reference from being saved:</h6>

--- a/app/views/references/_form_2.html.erb
+++ b/app/views/references/_form_2.html.erb
@@ -2,7 +2,7 @@
            
 <%= form_for(@reference,
              url: @reference.id.present? ? reference_path(id: @reference.id) : references_path,
-             role: 'form', remote: true
+             role: 'form', remote: true, data: { turbo: false }
             ) do |f| %>
  <% if @reference.errors.any? %>
     <div id="error_explanation">

--- a/app/views/references/_form_3.html.erb
+++ b/app/views/references/_form_3.html.erb
@@ -2,7 +2,7 @@
            
 <%= form_for(@reference,
              url: @reference.id.present? ? reference_path(id: @reference.id) : references_path,
-             role: 'form', remote: true
+             role: 'form', remote: true, data: { turbo: false }
             ) do |f| %>
  <% if @reference.errors.any? %>
     <div id="error_explanation">

--- a/app/views/references/tabs/_tab_edit_3.html.erb
+++ b/app/views/references/tabs/_tab_edit_3.html.erb
@@ -36,7 +36,7 @@
                                       reference_path(@reference.id),
                                       class: "btn btn-danger",
                                       title: "Confirm you want to delete the reference.",
-                                      remote: true,
+                                      remote: true, data: { turbo: false },
                                       method: :delete)
       %>
       <% cancel_delete_link = link_to("Cancel delete",

--- a/app/views/search/_set_include_common_and_cultivar.html.erb
+++ b/app/views/search/_set_include_common_and_cultivar.html.erb
@@ -10,7 +10,7 @@
 
 <%= link_to "#{icon('fa-sharp fa-regular fa-lg', icon_name)} Common/Cultivars".html_safe,
   set_include_common_and_cultivar_path,
-  remote: true,
+  remote: true, data: { turbo: false },
   method: :post,
   title: "Name searches will #{include_exclude} common names and cultivars",
   class: "" %>

--- a/app/views/search/_top_navbar.html.erb
+++ b/app/views/search/_top_navbar.html.erb
@@ -67,6 +67,7 @@
                     search_reports_path,
                     class: "main-body-tab-link",
                     remote: true,
+                    data: { turbo: false },
                     title: "List of query reports" %>
       </li>
       <li id="taxonomy-report-tab" role="presentation" class="<%= 'hidden' unless @working_draft %>">
@@ -74,6 +75,7 @@
                       trees_reports_path,
                       class: "main-body-tab-link",
                       remote: true,
+                      data: { turbo: false },
                       title: "Draft taxonomy reports" %>
       </li>
 

--- a/app/views/tree_versions/_drafts_menu.html.erb
+++ b/app/views/tree_versions/_drafts_menu.html.erb
@@ -27,7 +27,7 @@
         <%= link_to("#{menu_item.name} #{menu_item.draft_name} #{'(Default Draft)' if menu_item.default_draft}
                       #{editor_icon('check', '',{class: check_is_hidden})}".html_safe,
                       toggle_current_workspace_path(id: menu_item.draft_id),
-                      { remote: true,
+                      { remote: true, data: { turbo: false },
                         method: "post",
                         title: menu_item.log_entry || menu_item.draft_name }) %>
       <% else %>

--- a/app/views/tree_versions/_refresh.html.erb
+++ b/app/views/tree_versions/_refresh.html.erb
@@ -1,7 +1,7 @@
 <button onclick="refreshPage(event);">refresh page</button>
 <%= link_to("Switch to \"#{@created_version.draft_name}\"",
             toggle_current_workspace_path(id: @created_version.id),
-            {remote: true,
+            {remote: true, data: { turbo: false },
              method: "post",
              title: "Switch to draft",
              class: "btn btn-default"})

--- a/app/views/trees/tab_inners/_reports_inner.html.erb
+++ b/app/views/trees/tab_inners/_reports_inner.html.erb
@@ -6,7 +6,7 @@
         show_cas_path,
         id: "val-syn-tab-extra-new",
         class: 'nav-link tab',
-        remote: true,
+        remote: true, data: { turbo: false },
         method: :get,
         title: 'Check All Synonymy',
         "aria-controls": "Synonymy",
@@ -18,7 +18,7 @@
         show_diff_path,
         id: "diff-tab-new",
         class: 'nav-link tab',
-        remote: true,
+        remote: true, data: { turbo: false },
         method: :get,
         title: 'Draft Changes Report',
         "aria-controls": "Draft Changes Report",
@@ -30,7 +30,7 @@
         show_valrep_path,
         id: "valrep-tab-new",
         class: 'nav-link tab',
-        remote: true,
+        remote: true, data: { turbo: false },
         method: :get,
         title: 'Validation Report',
         "aria-controls": "Validation Report",
@@ -43,7 +43,7 @@
       <%= link_to "Run the Changes Report",
                       run_diff_path,
                       id: 'link-to-run-diff',
-                      remote: true,
+                      remote: true, data: { turbo: false },
                       class: 'btn btn-primary',
                       title: 'Run the Changes Report' %>
       <h5 id="diff-is-running-indicator" class="hidden"></h5>
@@ -76,7 +76,7 @@
       <%= link_to "Run the Validation Report",
                       run_valrep_path,
                       id: 'link-to-run-valrep',
-                      remote: true,
+                      remote: true, data: { turbo: false },
                       class: 'btn btn-primary',
                       title: 'Run the Validation Report' %>
       <h5 id="val-report-is-running-indicator" class="hidden"></h5>
@@ -95,7 +95,7 @@
       <%= link_to "Run the Synonymy Report",
                       run_cas_path,
                       id: 'link-to-run-cas',
-                      remote: true,
+                      remote: true, data: { turbo: false },
                       method: :get,
                       class: 'btn btn-primary',
                       title: 'Run or re-run the Synonymy Report.  It validates all synonyms.' %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(@user, as: 'user', role: 'form', remote: true
+<%= form_for(@user, as: 'user', role: 'form', remote: true, data: { turbo: false }
     ) do |f| %>
     <% if @user.errors.any? %>
         <div id="error_explanation">

--- a/app/views/users/tabs/_delete_widgets.html.erb
+++ b/app/views/users/tabs/_delete_widgets.html.erb
@@ -14,7 +14,7 @@
                                  class: "btn btn-danger confirm-delete-btn",
                                  tabindex: increment_tab_index,
                                  title: "Confirm you want to delete the user.",
-                                 remote: true,
+                                 remote: true, data: { turbo: false },
                                  method: :delete)
 %>
 

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,6 +1,10 @@
 - :date: 03-August-2026
   :jira_id: '5568'
   :description: |-
+    Intermittent 406 errors: Many more links needed the turbo-false switch to avoid potential 406 errors - BAU workflow testing only
+- :date: 03-August-2026
+  :jira_id: '5568'
+  :description: |-
     Intermittent 406 errors: Add code switches we expect will prevent these problems happening
 - :date: 03-August-2026
   :jira_id: '5858'

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.80
+appversion=5.1.4.81


### PR DESCRIPTION
## Description

I noticed some similar cases, asked Claude about them, and then Claude did a full sweep:


Claude:

All clear. Summary of the sweep:

Found 176 remote: true occurrences across the app; 8 already had a Turbo guard, 168 didn't.
Applied data: { turbo: false } to all 168, across 104 files (links, form_for/form_with/form_tag, and button_to/submit buttons).
Caught and fixed 2 real regressions from the blind transform: instance_notes/show.html.erb and names/form/_copy.html.erb each already had a top-level data: key, which would have silently collided with mine (Ruby just keeps the last one, so my fix would've been silently dropped). Merged those by hand instead of adding a duplicate key.
Verified all 104 changed files parse as valid Ruby (extracted the ERB's Ruby fragments and ran them through ruby -c), and confirmed zero remote: true occurrences remain unguarded.




## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
BAU Workflow


## Tests
- [x] Unit tests - I ran them, no new ones
- [ ] Manual testing


## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
