### PR TITLE
Nsl 5859 editor some checkboxes are stretched

### DIFF
--- a/app/views/authors/new_row.js.erb
+++ b/app/views/authors/new_row.js.erb
@@ -1,7 +1,8 @@
 
 if ($('#search-results-table tbody').length == 0) {
-  // No search results
-  $('#search-results-table').append("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");
+  // No search results.
+  $('#search-results-table').append('<tbody></tbody>');
+  $('#search-results-table tbody').append("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");
 } else {
   // Some search results
   $('#search-results-table tr:first').before("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");

--- a/app/views/loader/batches/new_row.js.erb
+++ b/app/views/loader/batches/new_row.js.erb
@@ -1,7 +1,8 @@
 
 if ($('#search-results-table tbody').length == 0) {
-  // No search results
-  $('#search-results-table').append("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");
+  // No search results.
+  $('#search-results-table').append('<tbody></tbody>');
+  $('#search-results-table tbody').append("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");
 } else {
   // Some search results
   $('#search-results-table tr:first').before("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");

--- a/app/views/loader/names/new_row.js.erb
+++ b/app/views/loader/names/new_row.js.erb
@@ -1,7 +1,8 @@
 
 if ($('#search-results-table tbody').length == 0) {
-  // No search results
-  $('#search-results-table').append("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");
+  // No search results.
+  $('#search-results-table').append('<tbody></tbody>');
+  $('#search-results-table tbody').append("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");
 } else {
   // Some search results
   $('#search-results-table tr:first').before("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");

--- a/app/views/names/new_row.js.erb
+++ b/app/views/names/new_row.js.erb
@@ -1,6 +1,7 @@
 if ($('#search-results-table tbody').length == 0) {
-  // No search results
-  $('#search-results-table').append("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");
+  // No search results.
+  $('#search-results-table').append('<tbody></tbody>');
+  $('#search-results-table tbody').append("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");
 } else {
   // Some search results
   $('#search-results-table tr:first').before("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");

--- a/app/views/references/new_row.js.erb
+++ b/app/views/references/new_row.js.erb
@@ -1,8 +1,9 @@
 
 
 if ($('#search-results-table tbody').length == 0) {
-  // No search results
-  $('#search-results-table').append("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");
+  // No search results.
+  $('#search-results-table').append('<tbody></tbody>');
+  $('#search-results-table tbody').append("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");
 } else {
   // Some search results
   $('#search-results-table tr:first').before("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");

--- a/app/views/users/new_row.js.erb
+++ b/app/views/users/new_row.js.erb
@@ -1,7 +1,8 @@
 
 if ($('#search-results-table tbody').length == 0) {
-  // No search results
-  $('#search-results-table').append("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");
+  // No search results.
+  $('#search-results-table').append('<tbody></tbody>');
+  $('#search-results-table tbody').append("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");
 } else {
   // Some search results
   $('#search-results-table tr:first').before("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -3,6 +3,10 @@
   :description: |-
     Search directives: Mark several directives as taking no argument
 - :date: 03-August-2026
+  :jira_id: '5859'
+  :description: |-
+    Fixup the stretched checkbox in bs5
+- :date: 03-August-2026
   :jira_id: '5568'
   :description: |-
     Intermittent 406 errors: Many more links needed the turbo-false switch to avoid potential 406 errors - BAU workflow testing only

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,11 +1,11 @@
+- :date: 03-August-2026
+  :jira_id: '5859'
+  :description: |-
+    Fixup the stretched checkbox in bs5 and the svg icon in the search results table
 - :date: 04-August-2026
   :jira_id: '5867'
   :description: |-
     Search directives: Mark several directives as taking no argument
-- :date: 03-August-2026
-  :jira_id: '5859'
-  :description: |-
-    Fixup the stretched checkbox in bs5
 - :date: 03-August-2026
   :jira_id: '5568'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.82
+appversion=5.1.4.83

--- a/vendor/assets/stylesheets/bootstrap5-compat.css
+++ b/vendor/assets/stylesheets/bootstrap5-compat.css
@@ -370,6 +370,32 @@ label.custom-checkbox input[type="checkbox"] {
   margin-left: 0.25rem;
 }
 
+input[type="checkbox"].form-control,
+input[type="radio"].form-control {
+  display: inline-block;
+  width: auto;
+  min-height: 0;
+  height: auto;
+  padding: 0;
+  -webkit-appearance: auto;
+     -moz-appearance: auto;
+          appearance: auto;
+  background-color: transparent;
+  background-image: none;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  vertical-align: middle;
+  margin-left: 0.25rem;
+}
+
+input[type="checkbox"].form-control:focus,
+input[type="radio"].form-control:focus {
+  background-color: transparent;
+  border: 0;
+  box-shadow: none;
+}
+
 /* --- Misc removed helpers --------------------------------------------------- */
 .center-block { display: block; margin-right: auto; margin-left: auto; }
 .text-muted   { color: #6c757d !important; }
@@ -705,6 +731,17 @@ tr.search-result td.main-content {
 /* For the green icon alignment with text */
 tr.search-result td.nsl-tiny-icon-container {
   padding-top: 6px !important;
+}
+
+table.search-results > :not(caption) > * > * {
+  background-color: transparent;
+  box-shadow: none;
+}
+
+svg.icon.name-icon {
+  width: 7px !important;
+  height: 13px !important;
+  overflow: hidden !important;
 }
 
 table[border] {

--- a/vendor/assets/stylesheets/bootstrap5-compat.css
+++ b/vendor/assets/stylesheets/bootstrap5-compat.css
@@ -741,6 +741,7 @@ table.search-results > :not(caption) > * > * {
 svg.icon.name-icon {
   width: 7px !important;
   height: 13px !important;
+  padding: 0 !important;
   overflow: hidden !important;
 }
 


### PR DESCRIPTION
## Description
- Fixup the stretched checkbox in bs5
- Fixup the missing svg icon with color in the search result when adding a new name, author, reference

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
