### PR TITLE
Nsl 5862 editor loader reference tab has table outline

### DIFF
--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,8 +1,8 @@
-- :date: 03-August-2026
+- :date: 04-August-2026
   :jira_id: '5862'
   :description: |-
     Fixup the loader refgerence tab table outline
-- :date: 03-August-2026
+- :date: 04-August-2026
   :jira_id: '5859'
   :description: |-
     Fixup the stretched checkbox in bs5 and the svg icon in the search results table

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 03-August-2026
+  :jira_id: '5862'
+  :description: |-
+    Fixup the loader refgerence tab table outline
+- :date: 03-August-2026
   :jira_id: '5859'
   :description: |-
     Fixup the stretched checkbox in bs5 and the svg icon in the search results table

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.83
+appversion=5.1.4.84

--- a/vendor/assets/stylesheets/bootstrap5-compat.css
+++ b/vendor/assets/stylesheets/bootstrap5-compat.css
@@ -396,6 +396,13 @@ input[type="radio"].form-control:focus {
   box-shadow: none;
 }
 
+input[type="file"]:focus,
+input[type="checkbox"]:focus,
+input[type="radio"]:focus {
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}
+
 /* --- Misc removed helpers --------------------------------------------------- */
 .center-block { display: block; margin-right: auto; margin-left: auto; }
 .text-muted   { color: #6c757d !important; }
@@ -745,11 +752,11 @@ svg.icon.name-icon {
   overflow: hidden !important;
 }
 
-table[border] {
+table[border]:not([border="0"]) {
   border-collapse: collapse;
 }
-table[border] th,
-table[border] td {
+table[border]:not([border="0"]) th,
+table[border]:not([border="0"]) td {
   border: 1px solid #999;
 }
 


### PR DESCRIPTION
## Description
- Fixup the editor loader reference tabe table outline for bs5
- Remove the gray outline of the radio button when in focus for bs5

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
