### PR TITLE
NSL-5789: Reference typeahead: apply chronological order using iso_publication_date

### DIFF
--- a/app/models/reference/as_typeahead/on_citation.rb
+++ b/app/models/reference/as_typeahead/on_citation.rb
@@ -65,7 +65,7 @@ class Reference::AsTypeahead::OnCitation
              .not_duplicate
              .where.not(reference: { id: excluded_id })
              .where(bound_terms_array(terms))
-             .order("citation")
+             .order(Arel.sql('iso_publication_date DESC NULLS FIRST'), 'citation')
              .limit(SEARCH_LIMIT)
   end
 end

--- a/app/models/reference/as_typeahead/on_citation_for_duplicate.rb
+++ b/app/models/reference/as_typeahead/on_citation_for_duplicate.rb
@@ -71,7 +71,7 @@ class Reference::AsTypeahead::OnCitationForDuplicate
              .where.not(reference: { id: current_id })
              .not_duplicate
              .where(bound_terms_array(terms))
-             .order("citation")
+             .order(Arel.sql('iso_publication_date DESC NULLS FIRST'), 'citation')
              .limit(SEARCH_LIMIT)
   end
 

--- a/app/models/reference/as_typeahead/on_citation_for_parent.rb
+++ b/app/models/reference/as_typeahead/on_citation_for_parent.rb
@@ -73,7 +73,7 @@ class Reference::AsTypeahead::OnCitationForParent
              .not_duplicate
              .where(bound_terms_array(terms))
              .where(ref_type_id: RefType.find(best_ref_type_id).parent_id)
-             .order("citation")
+             .order(Arel.sql('iso_publication_date DESC NULLS FIRST'), 'citation')
              .limit(SEARCH_LIMIT)
   end
 end

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 04-August-2026
+  :jira_id: '5789'
+  :description: |-
+    Reference typeahead: apply chronological order using <code>iso_publication_date</code>
 - :date: 03-August-2026
   :jira_id: '5859'
   :description: |-

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,7 +1,3 @@
-- :date: 04-August-2026
-  :jira_id: '5789'
-  :description: |-
-    Reference typeahead: apply chronological order using <code>iso_publication_date</code>
 - :date: 03-August-2026
   :jira_id: '5859'
   :description: |-

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 04-August-2026
+  :jira_id: '5789'
+  :description: |-
+    Reference typeahead: apply chronological order using <code>iso_publication_date</code>
+- :date: 04-August-2026
   :jira_id: '5862'
   :description: |-
     Fixup the loader refgerence tab table outline

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.83
+appversion=5.1.4.84

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.84
+appversion=5.1.4.83

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.84
+appversion=5.1.4.85

--- a/test/fixtures/references.yml
+++ b/test/fixtures/references.yml
@@ -2000,3 +2000,42 @@ fallback_later_reference:
   ref_author_role: dash
   ref_type: book
   iso_publication_date: 1980
+
+# Fixtures for the OnCitation / OnCitationForDuplicate / OnCitationForParent
+# typeahead order tests: NSL-5867 follow-up. All three share the
+# distinctive "flibbertigibbet" term (not used elsewhere) so a search for
+# it matches exactly these three and nothing else. ref_type is book so
+# they're valid results for all three typeahead classes (book isn't
+# excluded from OnCitation the way Journal is, and book is a valid parent
+# ref_type for section, used by the OnCitationForParent test).
+flibbertigibbet_no_date:
+  <<: *DEFAULTS
+  title: "Flibbertigibbet reference with no date"
+  citation: "Flibbertigibbet reference with no date"
+  citation_html: "Flibbertigibbet reference with no date"
+  display_title: "Flibbertigibbet reference with no date"
+  author: unknown
+  ref_author_role: dash
+  ref_type: book
+
+flibbertigibbet_early:
+  <<: *DEFAULTS
+  title: "Flibbertigibbet reference early"
+  citation: "Flibbertigibbet reference early"
+  citation_html: "Flibbertigibbet reference early"
+  display_title: "Flibbertigibbet reference early"
+  author: unknown
+  ref_author_role: dash
+  ref_type: book
+  iso_publication_date: 1800
+
+flibbertigibbet_late:
+  <<: *DEFAULTS
+  title: "Flibbertigibbet reference late"
+  citation: "Flibbertigibbet reference late"
+  citation_html: "Flibbertigibbet reference late"
+  display_title: "Flibbertigibbet reference late"
+  author: unknown
+  ref_author_role: dash
+  ref_type: book
+  iso_publication_date: 1990

--- a/test/models/reference/typeaheads/on_citation/order/orders_by_publication_date_desc_nulls_first_then_citation_test.rb
+++ b/test/models/reference/typeaheads/on_citation/order/orders_by_publication_date_desc_nulls_first_then_citation_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+require "test_helper"
+
+# Reference model typeahead search.
+# NSL-5867 follow-up: results should be ordered by iso_publication_date
+# descending, with references that have no date sorted first, then by
+# citation.
+class TAOnCitnOrdersByPublicationDateTest < ActiveSupport::TestCase
+  test "ref typeahead on citation orders by publication date desc nulls first then citation" do
+    typeahead = Reference::AsTypeahead::OnCitation.new("flibbertigibbet")
+
+    ids = typeahead.results.collect { |result| result[:id] }
+
+    assert_equal [references(:flibbertigibbet_no_date).id.to_s,
+                  references(:flibbertigibbet_late).id.to_s,
+                  references(:flibbertigibbet_early).id.to_s],
+                 ids,
+                 "Expected no-date reference first (nulls first), then " \
+                 "most recently published, then the earliest."
+  end
+end

--- a/test/models/reference/typeaheads/on_citation_for_duplicate/order/orders_by_publication_date_desc_nulls_first_then_citation_test.rb
+++ b/test/models/reference/typeaheads/on_citation_for_duplicate/order/orders_by_publication_date_desc_nulls_first_then_citation_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+require "test_helper"
+
+# Reference model typeahead search.
+# NSL-5867 follow-up: results should be ordered by iso_publication_date
+# descending, with references that have no date sorted first, then by
+# citation. `simple` is ref_type unknown, so no ref_type restriction is
+# applied and all three flibbertigibbet (book) fixtures are candidates.
+class TAOnCitationForDuplicateOrdersByPublicationDateTest < ActiveSupport::TestCase
+  test "ref typeahead on citation for duplicate orders by publication date desc nulls first then citation" do
+    typeahead = Reference::AsTypeahead::OnCitationForDuplicate.new(
+      "flibbertigibbet",
+      references(:simple).id
+    )
+
+    ids = typeahead.results.collect { |result| result[:id] }
+
+    assert_equal [references(:flibbertigibbet_no_date).id.to_s,
+                  references(:flibbertigibbet_late).id.to_s,
+                  references(:flibbertigibbet_early).id.to_s],
+                 ids,
+                 "Expected no-date reference first (nulls first), then " \
+                 "most recently published, then the earliest."
+  end
+end

--- a/test/models/reference/typeaheads/on_citation_for_parent/order/orders_by_publication_date_desc_nulls_first_then_citation_test.rb
+++ b/test/models/reference/typeaheads/on_citation_for_parent/order/orders_by_publication_date_desc_nulls_first_then_citation_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+require "test_helper"
+
+# Reference model typeahead search.
+# NSL-5867 follow-up: results should be ordered by iso_publication_date
+# descending, with references that have no date sorted first, then by
+# citation. Section's valid parent ref_type is Book, matching the
+# flibbertigibbet fixtures.
+class TAOnCitnForParentOrdersByPublicationDateTest < ActiveSupport::TestCase
+  test "ref typeahead on citation for parent orders by publication date desc nulls first then citation" do
+    current_reference = references(:simple)
+    typeahead = Reference::AsTypeahead::OnCitationForParent.new(
+      "flibbertigibbet",
+      current_reference.id,
+      ref_types(:section).id
+    )
+
+    ids = typeahead.results.collect { |result| result[:id] }
+
+    assert_equal [references(:flibbertigibbet_no_date).id.to_s,
+                  references(:flibbertigibbet_late).id.to_s,
+                  references(:flibbertigibbet_early).id.to_s],
+                 ids,
+                 "Expected no-date reference first (nulls first), then " \
+                 "most recently published, then the earliest."
+  end
+end


### PR DESCRIPTION
## Description
See Jira

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
See Jira

## Tests
- [x] Unit tests - Claude
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
